### PR TITLE
Implement `Save without Formatting` command

### DIFF
--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -17,41 +17,41 @@
 /* eslint-disable max-len, @typescript-eslint/indent */
 
 import debounce = require('lodash.debounce');
-import { injectable, inject } from 'inversify';
 import { TabBar, Widget } from '@phosphor/widgets';
-import { MAIN_MENU_BAR, SETTINGS_MENU, MenuContribution, MenuModelRegistry, ACCOUNTS_MENU } from '../common/menu';
-import { KeybindingContribution, KeybindingRegistry } from './keybinding';
-import { FrontendApplication, FrontendApplicationContribution } from './frontend-application';
-import { CommandContribution, CommandRegistry, Command } from '../common/command';
-import { UriAwareCommandHandler } from '../common/uri-command-handler';
-import { SelectionService } from '../common/selection-service';
-import { MessageService } from '../common/message-service';
-import { OpenerService, open } from '../browser/opener-service';
-import { ApplicationShell } from './shell/application-shell';
-import { SHELL_TABBAR_CONTEXT_MENU } from './shell/tab-bars';
-import { AboutDialog } from './about-dialog';
-import * as browser from './browser';
-import URI from '../common/uri';
-import { ContextKeyService } from './context-key-service';
-import { OS, isOSX, isWindows } from '../common/os';
-import { ResourceContextKey } from './resource-context-key';
-import { UriSelection } from '../common/selection';
-import { StorageService } from './storage-service';
-import { Navigatable } from './navigatable';
-import { QuickViewService } from './quick-view-service';
-import { PrefixQuickOpenService, QuickOpenItem, QuickOpenMode, QuickOpenService, QuickOpenGroupItem } from './quick-open';
 import { environment } from '@theia/application-package/lib/environment';
-import { IconThemeService } from './icon-theme-service';
-import { ColorContribution } from './color-application-contribution';
-import { ColorRegistry, Color } from './color-registry';
-import { CorePreferences } from './core-preferences';
-import { ThemeService } from './theming';
-import { PreferenceService, PreferenceScope } from './preferences';
-import { ClipboardService } from './clipboard-service';
-import { EncodingRegistry } from './encoding-registry';
+import { inject, injectable } from 'inversify';
+import { open, OpenerService } from '../browser/opener-service';
+import { Command, CommandContribution, CommandRegistry } from '../common/command';
 import { UTF8 } from '../common/encodings';
 import { EnvVariablesServer } from '../common/env-variables';
+import { ACCOUNTS_MENU, MAIN_MENU_BAR, MenuContribution, MenuModelRegistry, SETTINGS_MENU } from '../common/menu';
+import { MessageService } from '../common/message-service';
+import { isOSX, isWindows, OS } from '../common/os';
+import { UriSelection } from '../common/selection';
+import { SelectionService } from '../common/selection-service';
+import URI from '../common/uri';
+import { UriAwareCommandHandler } from '../common/uri-command-handler';
+import { AboutDialog } from './about-dialog';
 import { AuthenticationService } from './authentication-service';
+import * as browser from './browser';
+import { ClipboardService } from './clipboard-service';
+import { ColorContribution } from './color-application-contribution';
+import { Color, ColorRegistry } from './color-registry';
+import { ContextKeyService } from './context-key-service';
+import { CorePreferences } from './core-preferences';
+import { EncodingRegistry } from './encoding-registry';
+import { FrontendApplication, FrontendApplicationContribution } from './frontend-application';
+import { IconThemeService } from './icon-theme-service';
+import { KeybindingContribution, KeybindingRegistry } from './keybinding';
+import { Navigatable } from './navigatable';
+import { PreferenceScope, PreferenceService } from './preferences';
+import { PrefixQuickOpenService, QuickOpenGroupItem, QuickOpenItem, QuickOpenMode, QuickOpenService } from './quick-open';
+import { QuickViewService } from './quick-view-service';
+import { ResourceContextKey } from './resource-context-key';
+import { ApplicationShell } from './shell/application-shell';
+import { SHELL_TABBAR_CONTEXT_MENU } from './shell/tab-bars';
+import { StorageService } from './storage-service';
+import { ThemeService } from './theming';
 
 export namespace CommonMenus {
 
@@ -83,6 +83,10 @@ export namespace CommonMenus {
     // last menu item
     export const HELP = [...MAIN_MENU_BAR, '9_help'];
 
+}
+
+export interface SaveOptions {
+    readonly skipFormattingOnSave: boolean;
 }
 
 export namespace CommonCommands {
@@ -229,6 +233,11 @@ export namespace CommonCommands {
         id: 'core.save',
         category: FILE_CATEGORY,
         label: 'Save',
+    };
+    export const SAVE_WITHOUT_FORMATTING: Command = {
+        id: 'core.saveWithoutFormatting',
+        category: FILE_CATEGORY,
+        label: 'Save without Formatting',
     };
     export const SAVE_ALL: Command = {
         id: 'core.saveAll',
@@ -444,6 +453,9 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
 
         registry.registerMenuAction(CommonMenus.FILE_SAVE, {
             commandId: CommonCommands.SAVE.id
+        });
+        registry.registerMenuAction(CommonMenus.FILE_SAVE, {
+            commandId: CommonCommands.SAVE_WITHOUT_FORMATTING.id
         });
         registry.registerMenuAction(CommonMenus.FILE_SAVE, {
             commandId: CommonCommands.SAVE_ALL.id
@@ -747,6 +759,9 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
         commandRegistry.registerCommand(CommonCommands.SAVE, {
             execute: () => this.shell.save()
         });
+        commandRegistry.registerCommand(CommonCommands.SAVE_WITHOUT_FORMATTING, {
+            execute: () => this.shell.save({ skipFormattingOnSave: true })
+        });
         commandRegistry.registerCommand(CommonCommands.SAVE_ALL, {
             execute: () => this.shell.saveAll()
         });
@@ -923,6 +938,10 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             {
                 command: CommonCommands.SAVE.id,
                 keybinding: 'ctrlcmd+s'
+            },
+            {
+                command: CommonCommands.SAVE_WITHOUT_FORMATTING.id,
+                keybinding: 'ctrlcmd+k s'
             },
             {
                 command: CommonCommands.SAVE_ALL.id,

--- a/packages/core/src/browser/saveable.ts
+++ b/packages/core/src/browser/saveable.ts
@@ -14,12 +14,13 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Widget } from '@phosphor/widgets';
 import { Message } from '@phosphor/messaging';
+import { Widget } from '@phosphor/widgets';
 import { Event } from '../common/event';
 import { MaybePromise } from '../common/types';
-import { Key } from './keyboard/keys';
+import { SaveOptions } from './common-frontend-contribution';
 import { AbstractDialog } from './dialogs';
+import { Key } from './keyboard/keys';
 import { waitForClosed } from './widgets';
 
 export interface Saveable {
@@ -29,7 +30,7 @@ export interface Saveable {
     /**
      * Saves dirty changes.
      */
-    save(): MaybePromise<void>;
+    save(options?: SaveOptions): MaybePromise<void>;
     /**
      * Reverts dirty changes.
      */
@@ -87,10 +88,10 @@ export namespace Saveable {
         return !!getDirty(arg);
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    export async function save(arg: any): Promise<void> {
+    export async function save(arg: any, options?: SaveOptions): Promise<void> {
         const saveable = get(arg);
         if (saveable) {
-            await saveable.save();
+            await saveable.save(options);
         }
     }
     export function apply(widget: Widget): SaveableWidget | undefined {

--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -14,28 +14,29 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { injectable, inject, optional, postConstruct } from 'inversify';
-import { ArrayExt, find, toArray, each } from '@phosphor/algorithm';
+import { ArrayExt, each, find, toArray } from '@phosphor/algorithm';
+import { IDragEvent } from '@phosphor/dragdrop';
+import { Message } from '@phosphor/messaging';
 import { Signal } from '@phosphor/signaling';
 import {
     BoxLayout, BoxPanel, DockLayout, DockPanel, FocusTracker, Layout, Panel, SplitLayout,
-    SplitPanel, TabBar, Widget, Title
+    SplitPanel, TabBar, Title, Widget
 } from '@phosphor/widgets';
-import { Message } from '@phosphor/messaging';
-import { IDragEvent } from '@phosphor/dragdrop';
-import { RecursivePartial, Event as CommonEvent, DisposableCollection, Disposable } from '../../common';
-import { animationFrame } from '../browser';
-import { Saveable, SaveableWidget } from '../saveable';
-import { StatusBarImpl, StatusBarEntry, StatusBarAlignment } from '../status-bar/status-bar';
-import { TheiaDockPanel, BOTTOM_AREA_ID, MAIN_AREA_ID } from './theia-dock-panel';
-import { SidePanelHandler, SidePanel, SidePanelHandlerFactory } from './side-panel-handler';
-import { TabBarRendererFactory, TabBarRenderer, SHELL_TABBAR_CONTEXT_MENU, ScrollableTabBar, ToolbarAwareTabBar } from './tab-bars';
-import { SplitPositionHandler, SplitPositionOptions } from './split-panels';
-import { FrontendApplicationStateService } from '../frontend-application-state';
-import { TabBarToolbarRegistry, TabBarToolbarFactory, TabBarToolbar } from './tab-bar-toolbar';
-import { ContextKeyService } from '../context-key-service';
+import { inject, injectable, optional, postConstruct } from 'inversify';
+import { Disposable, DisposableCollection, Event as CommonEvent, RecursivePartial } from '../../common';
 import { Emitter } from '../../common/event';
-import { waitForRevealed, waitForClosed } from '../widgets';
+import { animationFrame } from '../browser';
+import { SaveOptions } from '../common-frontend-contribution';
+import { ContextKeyService } from '../context-key-service';
+import { FrontendApplicationStateService } from '../frontend-application-state';
+import { Saveable, SaveableWidget } from '../saveable';
+import { StatusBarAlignment, StatusBarEntry, StatusBarImpl } from '../status-bar/status-bar';
+import { waitForClosed, waitForRevealed } from '../widgets';
+import { SidePanel, SidePanelHandler, SidePanelHandlerFactory } from './side-panel-handler';
+import { SplitPositionHandler, SplitPositionOptions } from './split-panels';
+import { TabBarToolbar, TabBarToolbarFactory, TabBarToolbarRegistry } from './tab-bar-toolbar';
+import { ScrollableTabBar, SHELL_TABBAR_CONTEXT_MENU, TabBarRenderer, TabBarRendererFactory, ToolbarAwareTabBar } from './tab-bars';
+import { BOTTOM_AREA_ID, MAIN_AREA_ID, TheiaDockPanel } from './theia-dock-panel';
 
 /** The class name added to ApplicationShell instances. */
 const APPLICATION_SHELL_CLASS = 'theia-ApplicationShell';
@@ -1731,8 +1732,8 @@ export class ApplicationShell extends Widget {
     /**
      * Save the current widget if it is dirty.
      */
-    async save(): Promise<void> {
-        await Saveable.save(this.currentWidget);
+    async save(options?: SaveOptions): Promise<void> {
+        await Saveable.save(this.currentWidget, options);
     }
 
     /**
@@ -1746,7 +1747,7 @@ export class ApplicationShell extends Widget {
      * Save all dirty widgets.
      */
     async saveAll(): Promise<void> {
-        await Promise.all(this.tracker.widgets.map(Saveable.save));
+        await Promise.all(this.tracker.widgets.map(widget => Saveable.save(widget)));
     }
 
     /**

--- a/packages/monaco/src/browser/monaco-editor-model.ts
+++ b/packages/monaco/src/browser/monaco-editor-model.ts
@@ -14,18 +14,18 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Position } from 'vscode-languageserver-types';
-import { TextDocumentSaveReason, TextDocumentContentChangeEvent } from 'vscode-languageserver-protocol';
-import { TextEditorDocument, EncodingMode } from '@theia/editor/lib/browser';
-import { DisposableCollection, Disposable } from '@theia/core/lib/common/disposable';
-import { Emitter, Event } from '@theia/core/lib/common/event';
-import { CancellationTokenSource, CancellationToken } from '@theia/core/lib/common/cancellation';
-import { Resource, ResourceError, ResourceVersion } from '@theia/core/lib/common/resource';
-import { Range } from 'vscode-languageserver-types';
 import { Saveable } from '@theia/core/lib/browser/saveable';
+import { CancellationToken, CancellationTokenSource } from '@theia/core/lib/common/cancellation';
+import { Disposable, DisposableCollection } from '@theia/core/lib/common/disposable';
+import { Emitter, Event } from '@theia/core/lib/common/event';
+import { ILogger, Log, Loggable } from '@theia/core/lib/common/logger';
+import { Resource, ResourceError, ResourceVersion } from '@theia/core/lib/common/resource';
+import { SaveOptions } from '@theia/core/src/browser/common-frontend-contribution';
+import { EncodingMode, TextEditorDocument } from '@theia/editor/lib/browser';
+import { TextDocumentContentChangeEvent, TextDocumentSaveReason } from 'vscode-languageserver-protocol';
+import { Position, Range } from 'vscode-languageserver-types';
 import { MonacoToProtocolConverter } from './monaco-to-protocol-converter';
 import { ProtocolToMonacoConverter } from './protocol-to-monaco-converter';
-import { ILogger, Loggable, Log } from '@theia/core/lib/common/logger';
 
 export {
     TextDocumentSaveReason
@@ -36,6 +36,7 @@ type ITextEditorModel = monaco.editor.ITextEditorModel;
 export interface WillSaveMonacoModelEvent {
     readonly model: MonacoEditorModel;
     readonly reason: TextDocumentSaveReason;
+    readonly options?: SaveOptions;
     waitUntil(thenable: Thenable<monaco.editor.IIdentifiedSingleEditOperation[]>): void;
 }
 
@@ -283,8 +284,8 @@ export class MonacoEditorModel implements ITextEditorModel, TextEditorDocument {
         return this;
     }
 
-    save(): Promise<void> {
-        return this.scheduleSave(TextDocumentSaveReason.Manual);
+    save(options?: SaveOptions): Promise<void> {
+        return this.scheduleSave(TextDocumentSaveReason.Manual, undefined, undefined, options);
     }
 
     protected pendingOperation = Promise.resolve();
@@ -397,8 +398,8 @@ export class MonacoEditorModel implements ITextEditorModel, TextEditorDocument {
         return this.saveCancellationTokenSource.token;
     }
 
-    protected scheduleSave(reason: TextDocumentSaveReason, token: CancellationToken = this.cancelSave(), overwriteEncoding?: boolean): Promise<void> {
-        return this.run(() => this.doSave(reason, token, overwriteEncoding));
+    protected scheduleSave(reason: TextDocumentSaveReason, token: CancellationToken = this.cancelSave(), overwriteEncoding?: boolean, options?: SaveOptions): Promise<void> {
+        return this.run(() => this.doSave(reason, token, overwriteEncoding, options));
     }
 
     protected ignoreContentChanges = false;
@@ -457,12 +458,12 @@ export class MonacoEditorModel implements ITextEditorModel, TextEditorDocument {
         }
     }
 
-    protected async doSave(reason: TextDocumentSaveReason, token: CancellationToken, overwriteEncoding?: boolean): Promise<void> {
+    protected async doSave(reason: TextDocumentSaveReason, token: CancellationToken, overwriteEncoding?: boolean, options?: SaveOptions): Promise<void> {
         if (token.isCancellationRequested || !this.resource.saveContents) {
             return;
         }
 
-        await this.fireWillSaveModel(reason, token);
+        await this.fireWillSaveModel(reason, token, options);
         if (token.isCancellationRequested) {
             return;
         }
@@ -496,7 +497,7 @@ export class MonacoEditorModel implements ITextEditorModel, TextEditorDocument {
         }
     }
 
-    protected async fireWillSaveModel(reason: TextDocumentSaveReason, token: CancellationToken): Promise<void> {
+    protected async fireWillSaveModel(reason: TextDocumentSaveReason, token: CancellationToken, options?: SaveOptions): Promise<void> {
         type EditContributor = Thenable<monaco.editor.IIdentifiedSingleEditOperation[]>;
 
         const firing = this.onWillSaveModelEmitter.sequence(async listener => {
@@ -507,7 +508,7 @@ export class MonacoEditorModel implements ITextEditorModel, TextEditorDocument {
             const { version } = this;
 
             const event = {
-                model: this, reason,
+                model: this, reason, options,
                 waitUntil: (thenable: EditContributor) => {
                     if (Object.isFrozen(waitables)) {
                         throw new Error('waitUntil cannot be called asynchronously.');


### PR DESCRIPTION




<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
+ Adds key binding of `ctrlcmd+k+s` to save without formatting
+ Implements the command
+ Sorts imports using `organize imports` in files:
	- `packages/core/src/browser/common-frontend-contribution.ts`
	- `packages/core/src/browser/saveable.ts`
	- `packages/core/src/browser/shell/application-shell.ts`
	- `packages/monaco/src/browser/monaco-editor-model.ts`
	- `packages/monaco/src/browser/monaco-editor-provider.ts`

#### How to test
+ Make change to a file, enter command palette, search for `Save without Formatting`
+ The file is saved, but the formatter is not applied to the file.

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Duc Nguyen <duc.a.nguyen@ericsson.com>
