### PR TITLE
siw: Perform workspace search in all opening editors

### DIFF
--- a/packages/editor/src/browser/editor.ts
+++ b/packages/editor/src/browser/editor.ts
@@ -150,6 +150,46 @@ export const enum EncodingMode {
     Decode
 }
 
+/**
+ * Options for searching in an editor.
+ */
+export interface FindMatchesOptions {
+    /**
+     * The string used to search. If it is a regular expression, set `isRegex` to true.
+     */
+    searchString: string;
+    /**
+     * Used to indicate that `searchString` is a regular expression.
+     */
+    isRegex: boolean;
+    /**
+     * Force the matching to match lower/upper case exactly.
+     */
+    matchCase: boolean;
+    /**
+     * Force the matching to match entire words only.
+     */
+    matchWholeWord: boolean;
+    /**
+     * Limit the number of results.
+     */
+    limitResultCount?: number;
+}
+
+/**
+ * Representation of a find match.
+ */
+export interface FindMatch {
+    /**
+     * The textual match.
+     */
+    readonly matches: string[];
+    /**
+     * The range for the given match.
+     */
+    readonly range: Range;
+}
+
 export interface TextEditor extends Disposable, TextEditorSelection, Navigatable {
     readonly node: HTMLElement;
 
@@ -237,6 +277,22 @@ export interface TextEditor extends Disposable, TextEditorSelection, Navigatable
     setEncoding(encoding: string, mode: EncodingMode): void;
 
     readonly onEncodingChanged: Event<string>;
+
+    /**
+     * Find all matches in an editor for the given options.
+     * @param options the options for finding matches.
+     *
+     * @returns the list of matches.
+     */
+    findMatches?(options: FindMatchesOptions): FindMatch[];
+
+    /**
+     * Get the text for a certain line.
+     * @param lineNumber the line number.
+     *
+     * @returns the text at the given line.
+     */
+    getLineContent?(lineNumber: number): string;
 }
 
 export interface Dimension {

--- a/packages/search-in-workspace/package.json
+++ b/packages/search-in-workspace/package.json
@@ -9,6 +9,7 @@
     "@theia/navigator": "^1.6.0",
     "@theia/process": "^1.6.0",
     "@theia/workspace": "^1.6.0",
+    "minimatch": "^3.0.4",
     "vscode-ripgrep": "^1.2.4"
   },
   "publishConfig": {


### PR DESCRIPTION
+ `Search In Workspace` can now search content in dirty files and display the results in siw view.
+ Utilized the `findMatches` function from `monaco editor` to get the search matches.
+ Added `minimatch`, `fast-deep-equal` as dependencies in `siw`

Co-authored-by: fangnx <naxin.fang@ericsson.com>
Co-authored-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
Signed-off-by: DukeNgn <duc.a.nguyen@ericsson.com>



