### PR TITLE
editor: Add preference to close the editor when file is deleted on disk

### DIFF
--- a/examples/api-tests/src/saveable.spec.js
+++ b/examples/api-tests/src/saveable.spec.js
@@ -291,7 +291,7 @@ describe('Saveable', function () {
         try {
             await fileService.delete(fileUri);
             await waitForDidChangeTitle.promise;
-            assert.isTrue(widget.title.label.endsWith('(deleted from disk)'), 'should be marked as deleted');
+            assert.isTrue(widget.title.label.endsWith('(deleted)'), 'should be marked as deleted');
             assert.isTrue(Saveable.isDirty(widget), 'should be dirty after delete');
             assert.isFalse(widget.isDisposed, 'model should NOT be disposed after delete');
         } finally {
@@ -303,7 +303,7 @@ describe('Saveable', function () {
         try {
             await fileService.create(fileUri, 'foo');
             await waitForDidChangeTitle.promise;
-            assert.isFalse(widget.title.label.endsWith('(deleted from disk)'), 'should NOT be marked as deleted');
+            assert.isFalse(widget.title.label.endsWith('(deleted)'), 'should NOT be marked as deleted');
             assert.isTrue(Saveable.isDirty(widget), 'should be dirty after added again');
             assert.isFalse(widget.isDisposed, 'model should NOT be disposed after added again');
         } finally {

--- a/packages/core/src/browser/core-preferences.ts
+++ b/packages/core/src/browser/core-preferences.ts
@@ -36,6 +36,12 @@ export const corePreferenceSchema: PreferenceSchema = {
             'description': 'Controls whether a top border is drawn on modified (dirty) editor tabs or not.',
             'default': false
         },
+        'workbench.editor.closeOnFileDelete': {
+            'type': 'boolean',
+            // eslint-disable-next-line max-len
+            'description': 'Controls whether editors showing a file that was opened during the session should close automatically when getting deleted or renamed by some other process. Disabling this will keep the editor open  on such an event. Note that deleting from within the application will always close the editor and that dirty files will never close to preserve your data.',
+            'default': false
+        },
         'application.confirmExit': {
             type: 'string',
             enum: [
@@ -100,6 +106,7 @@ export interface CoreConfiguration {
     'workbench.list.openMode': 'singleClick' | 'doubleClick';
     'workbench.commandPalette.history': number;
     'workbench.editor.highlightModifiedTabs': boolean;
+    'workbench.editor.closeOnFileDelete': boolean;
     'workbench.colorTheme': string;
     'workbench.iconTheme': string | null;
     'workbench.silentNotifications': boolean;


### PR DESCRIPTION
+ Change `deletedSuffix` to ` (deleted)`
+ Add new preference `workbench.editor.closeOnFileDelete` (`false` by default) to control whether the editor should be closed if other processes deleted or renamed the file.

Signed-off-by: Duc Nguyen <duc.a.nguyen@ericsson.com>



