### PR TITLE
siw: Add searchOnType and debounce for search on type

### DIFF
--- a/packages/search-in-workspace/src/browser/search-in-workspace-preferences.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-preferences.ts
@@ -30,13 +30,26 @@ export const searchInWorkspacePreferencesSchema: PreferenceSchema = {
             default: 'auto',
             type: 'string',
             enum: ['auto', 'alwaysCollapse', 'alwaysExpand'],
-        }
+        },
+        'search.searchOnType': {
+            description: 'Search all files as you type in the search field.',
+            default: true,
+            type: 'boolean',
+        },
+        'search.searchOnTypeDebouncePeriod': {
+            // eslint-disable-next-line max-len
+            description: 'When `search.searchOnType` is enabled, controls the timeout in milliseconds between a character being typed and the search starting. Has no effect when `search.searchOnType` is disabled.',
+            default: 300,
+            type: 'number',
+        },
     }
 };
 
 export class SearchInWorkspaceConfiguration {
     'search.lineNumbers': boolean;
     'search.collapseResults': string;
+    'search.searchOnType': boolean;
+    'search.searchOnTypeDebouncePeriod': number;
 }
 
 export const SearchInWorkspacePreferences = Symbol('SearchInWorkspacePreferences');


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

+ Add preference `search.searchOnEditorModification`. Enabling this option will make the search results in search view automatically get updated as user modify the  editor.

Signed-off-by: Duc Nguyen <duc.a.nguyen@ericsson.com>