### PR TITLE
editor: add command `Reopen Closed Editor`

### DIFF
--- a/packages/core/src/common/uri.spec.ts
+++ b/packages/core/src/common/uri.spec.ts
@@ -229,4 +229,37 @@ describe('uri', () => {
         });
     });
 
+    describe('#isEqual', () => {
+        it('should return `true` for `uris` which are equal', () => {
+            const a = new URI('file:///C:/projects/theia/foo/a.ts');
+            const b = new URI('file:///C:/projects/theia/foo/a.ts');
+            expect(a.isEqual(b)).equals(true);
+        });
+        it('should return `false` for `uris` which are not equal', () => {
+            const a = new URI('file:///C:/projects/theia/foo/a.ts');
+            const b = new URI('file:///C:/projects/theia/foo/b.ts');
+            expect(a.isEqual(b)).equals(false);
+        });
+        it('should return `true` for `uris` that are not case-sensitive equal, with case-sensitivity `off`', () => {
+            const a = new URI('file:///C:/projects/theia/foo/a.ts');
+            const b = new URI('file:///C:/projects/theia/foo/A.ts');
+            expect(a.isEqual(b, false)).equals(true);
+        });
+        it('should return `false` for `uris` that are not case-sensitive equal, with case-sensitivity `on`', () => {
+            const a = new URI('file:///C:/projects/theia/foo/a.ts');
+            const b = new URI('file:///C:/projects/theia/foo/A.ts');
+            expect(a.isEqual(b, true)).equals(false);
+        });
+        it('should return `false` for parent paths', () => {
+            const a = new URI('file:///C:/projects/'); // parent uri.
+            const b = new URI('file:///C:/projects/theia/foo');
+            expect(a.isEqual(b)).equals(false);
+        });
+        it('should return `false` for different schemes', () => {
+            const a = new URI('a:///C:/projects/theia/foo/a.ts');
+            const b = new URI('b:///C:/projects/theia/foo/a.ts');
+            expect(a.isEqual(b)).equals(false);
+        });
+    });
+
 });

--- a/packages/core/src/common/uri.ts
+++ b/packages/core/src/common/uri.ts
@@ -199,8 +199,18 @@ export default class URI {
         return this.codeUri.toString(skipEncoding);
     }
 
+    isEqual(uri: URI, caseSensitive: boolean = true): boolean {
+        if (!this.hasSameSchemeAuthority(uri)) {
+            return false;
+        }
+
+        return caseSensitive
+            ? this.toString() === uri.toString()
+            : this.toString().toLowerCase() === uri.toString().toLowerCase();
+    }
+
     isEqualOrParent(uri: URI, caseSensitive: boolean = true): boolean {
-        if (this.authority !== uri.authority || this.scheme !== uri.scheme) {
+        if (!this.hasSameSchemeAuthority(uri)) {
             return false;
         }
         let left = this.path;
@@ -222,4 +232,7 @@ export default class URI {
         return result;
     }
 
+    private hasSameSchemeAuthority(uri: URI): boolean {
+        return (this.authority === uri.authority) && (this.scheme === uri.scheme);
+    }
 }

--- a/packages/editor/src/browser/editor-command.ts
+++ b/packages/editor/src/browser/editor-command.ts
@@ -133,6 +133,14 @@ export namespace EditorCommands {
         category: 'View',
         label: 'Toggle Word Wrap'
     };
+    /**
+     * Command that re-opens the last closed editor.
+     */
+    export const REOPEN_CLOSED_EDITOR: Command = {
+        id: 'editor.action.reopenClosedEditor',
+        category: 'View',
+        label: 'Reopen Closed Editor'
+    };
 }
 
 @injectable()
@@ -199,6 +207,7 @@ export class EditorCommandContribution implements CommandContribution {
         registry.registerCommand(EditorCommands.TOGGLE_MINIMAP);
         registry.registerCommand(EditorCommands.TOGGLE_RENDER_WHITESPACE);
         registry.registerCommand(EditorCommands.TOGGLE_WORD_WRAP);
+        registry.registerCommand(EditorCommands.REOPEN_CLOSED_EDITOR);
 
         registry.registerCommand(CommonCommands.AUTO_SAVE, {
             isToggled: () => this.isAutoSaveOn(),

--- a/packages/editor/src/browser/editor-keybinding.ts
+++ b/packages/editor/src/browser/editor-keybinding.ts
@@ -39,6 +39,10 @@ export class EditorKeybindingContribution implements KeybindingContribution {
             {
                 command: EditorCommands.TOGGLE_WORD_WRAP.id,
                 keybinding: 'alt+z'
+            },
+            {
+                command: EditorCommands.REOPEN_CLOSED_EDITOR.id,
+                keybinding: 'alt+shift+t'
             }
         );
     }

--- a/packages/editor/src/browser/editor-navigation-contribution.ts
+++ b/packages/editor/src/browser/editor-navigation-contribution.ts
@@ -91,6 +91,9 @@ export class EditorNavigationContribution implements Disposable, FrontendApplica
             execute: () => this.toggleWordWrap(),
             isEnabled: () => true,
         });
+        this.commandRegistry.registerHandler(EditorCommands.REOPEN_CLOSED_EDITOR.id, {
+            execute: () => this.editorManager.reopenLastClosedEditor(),
+        });
     }
 
     async onStart(): Promise<void> {


### PR DESCRIPTION

#### What it does
+ Add new command `Reopen Closed Editor` opens the last closed editor.

#### How to test
+ Close an editor
+ + The command can be called from the command palette or by keyboard
  shortcut: `alt+shift+t`.

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Duc Nguyen <duc.a.nguyen@ericsson.com>

