### PR TITLE
Initial contribution of external terminal (clean version)

### DIFF
--- a/configs/root-compilation.tsconfig.json
+++ b/configs/root-compilation.tsconfig.json
@@ -138,6 +138,9 @@
     },
     {
       "path": "../packages/timeline/compile.tsconfig.json"
+    },
+    {
+      "path": "../packages/terminal-external/compile.tsconfig.json"
     }
   ]
 }

--- a/examples/electron/compile.tsconfig.json
+++ b/examples/electron/compile.tsconfig.json
@@ -124,6 +124,9 @@
     },
     {
       "path": "../../packages/timeline/compile.tsconfig.json"
+    },
+    {
+      "path": "../../packages/terminal-external/compile.tsconfig.json"
     }
   ]
 }

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -47,6 +47,7 @@
     "@theia/search-in-workspace": "1.11.0",
     "@theia/task": "1.11.0",
     "@theia/terminal": "1.11.0",
+    "@theia/terminal-external": "1.11.0",
     "@theia/timeline": "1.11.0",
     "@theia/typehierarchy": "1.11.0",
     "@theia/userstorage": "1.11.0",

--- a/packages/terminal-external/.eslintrc.js
+++ b/packages/terminal-external/.eslintrc.js
@@ -1,0 +1,10 @@
+/** @type {import('eslint').Linter.Config} */
+module.exports = {
+    extends: [
+        '../../configs/build.eslintrc.json'
+    ],
+    parserOptions: {
+        tsconfigRootDir: __dirname,
+        project: 'compile.tsconfig.json'
+    }
+};

--- a/packages/terminal-external/README.md
+++ b/packages/terminal-external/README.md
@@ -1,0 +1,32 @@
+<div align='center'>
+
+<br />
+
+<img src='https://raw.githubusercontent.com/eclipse-theia/theia/master/logo/theia.svg?sanitize=true' alt='theia-ext-logo' width='100px' />
+
+<h2>ECLIPSE THEIA - TERMINAL-EXTERNAL EXTENSION</h2>
+
+<hr />
+
+</div>
+
+## Description
+
+The `@theia/terminal-external` extension contributes the ability to spawn external terminals from the Electron application.
+
+**Note:** The extension does not support browser applications.
+
+## Additional Information
+
+- [Theia - GitHub](https://github.com/eclipse-theia/theia)
+- [Theia - Website](https://theia-ide.org/)
+
+## License
+
+-   [Eclipse Public License 2.0](http://www.eclipse.org/legal/epl-2.0/)
+-   [一 (Secondary) GNU General Public License, version 2 with the GNU Classpath Exception](https://projects.eclipse.org/license/secondary-gpl-2.0-cp)
+
+## Trademark
+
+"Theia" is a trademark of the Eclipse Foundation
+https://www.eclipse.org/theia

--- a/packages/terminal-external/compile.tsconfig.json
+++ b/packages/terminal-external/compile.tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../configs/base.tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": [
+    "src"
+  ],
+  "references": [
+    {
+      "path": "../core/compile.tsconfig.json"
+    },
+    {
+      "path": "../editor/compile.tsconfig.json"
+    },
+    {
+      "path": "../workspace/compile.tsconfig.json"
+    }
+  ]
+}

--- a/packages/terminal-external/package.json
+++ b/packages/terminal-external/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@theia/terminal-external",
+  "version": "1.11.0",
+  "description": "Theia - External Terminal Extension",
+  "dependencies": {
+    "@theia/core": "1.11.0",
+    "@theia/editor": "1.11.0",
+    "@theia/workspace": "1.11.0",
+    "fs-extra": "^4.0.2"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "theiaExtensions": [
+    {
+      "backendElectron": "lib/electron-node/terminal-external-backend-module",
+      "frontendElectron": "lib/electron-browser/terminal-external-frontend-module"
+    }
+  ],
+  "keywords": [
+    "theia-extension"
+  ],
+  "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/eclipse-theia/theia.git"
+  },
+  "bugs": {
+    "url": "https://github.com/eclipse-theia/theia/issues"
+  },
+  "homepage": "https://github.com/eclipse-theia/theia",
+  "files": [
+    "lib",
+    "src"
+  ],
+  "scripts": {
+    "lint": "theiaext lint",
+    "build": "theiaext build",
+    "watch": "theiaext watch",
+    "clean": "theiaext clean",
+    "test": "theiaext test"
+  },
+  "devDependencies": {
+    "@theia/ext-scripts": "^1.9.0"
+  },
+  "nyc": {
+    "extends": "../../configs/nyc.json"
+  }
+}

--- a/packages/terminal-external/src/common/terminal-external.ts
+++ b/packages/terminal-external/src/common/terminal-external.ts
@@ -25,14 +25,14 @@ export interface TerminalExternalConfiguration {
 
 export interface TerminalExternalService {
     /**
-     * Open native terminal in the provided path.
-     * @param configuration the configuration for opening external terminal.
-     * @param cwd the string that terminal should start in.
+     * Open a native terminal at the current working directory.
+     * @param configuration the configuration for opening external terminals.
+     * @param cwd the current working directory where the terminal should open from.
      */
     openTerminal(configuration: TerminalExternalConfiguration, cwd: string): Promise<void>;
     /**
      * Determine the default exec of the external terminal.
-     * @returns the string of the default terminal exec.
+     * @returns the default terminal exec.
      */
     getDefaultExec(): Promise<string>;
 }

--- a/packages/terminal-external/src/common/terminal-external.ts
+++ b/packages/terminal-external/src/common/terminal-external.ts
@@ -1,0 +1,33 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+export const TerminalExternalService = Symbol('TerminalExternalService');
+export const terminalExternalServicePath = '/services/terminal-external';
+
+export interface TerminalExternalConfiguration {
+    'terminal.external.windowsExec': string
+    'terminal.external.osxExec': string
+    'terminal.external.linuxExec': string
+}
+
+export interface TerminalExternalService {
+    /**
+     * Open native terminal in the provided path.
+     * @param configuration the configuration for opening external terminal.
+     * @param cwd the string that terminal should start in.
+     */
+    openTerminal(configuration: TerminalExternalConfiguration, cwd: string): Promise<void>;
+}

--- a/packages/terminal-external/src/common/terminal-external.ts
+++ b/packages/terminal-external/src/common/terminal-external.ts
@@ -30,4 +30,9 @@ export interface TerminalExternalService {
      * @param cwd the string that terminal should start in.
      */
     openTerminal(configuration: TerminalExternalConfiguration, cwd: string): Promise<void>;
+    /**
+     * Determine the default exec of the external terminal.
+     * @returns the string of the default terminal exec.
+     */
+    getDefaultExec(): Promise<string>;
 }

--- a/packages/terminal-external/src/electron-browser/terminal-external-contribution.ts
+++ b/packages/terminal-external/src/electron-browser/terminal-external-contribution.ts
@@ -1,0 +1,136 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject } from 'inversify';
+import {
+    CommandContribution,
+    CommandRegistry,
+    Command
+} from '@theia/core/lib/common';
+import { LabelProvider } from '@theia/core/lib/browser';
+import { KeybindingContribution, KeybindingRegistry } from '@theia/core/lib/browser';
+import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
+import { QuickPickService } from '@theia/core/lib/common/quick-pick-service';
+import { WorkspaceService } from '@theia/workspace/lib/browser';
+import { EditorManager } from '@theia/editor/lib/browser/editor-manager';
+import { TerminalExternalPreferences } from './terminal-external-preference';
+import { TerminalExternalService, TerminalExternalConfiguration } from '../common/terminal-external';
+
+export namespace TerminalExternalCommands {
+    export const OPEN_NATIVE_CONSOLE: Command = {
+        id: 'workbench.action.terminal.openNativeConsole',
+        label: 'Open New External Terminal'
+    };
+}
+
+@injectable()
+export class TerminalExternalFrontendContribution implements CommandContribution, KeybindingContribution {
+
+    @inject(EditorManager)
+    private readonly editorManager: EditorManager;
+
+    @inject(EnvVariablesServer)
+    private readonly envVariablesServer: EnvVariablesServer;
+
+    @inject(LabelProvider)
+    protected readonly labelProvider: LabelProvider;
+
+    @inject(QuickPickService)
+    private readonly quickPickService: QuickPickService;
+
+    @inject(TerminalExternalPreferences)
+    protected readonly terminalExternalPreferences: TerminalExternalPreferences;
+
+    @inject(TerminalExternalService)
+    private readonly terminalExternalService: TerminalExternalService;
+
+    @inject(WorkspaceService)
+    private readonly workspaceService: WorkspaceService;
+
+    registerCommands(commands: CommandRegistry): void {
+        commands.registerCommand(TerminalExternalCommands.OPEN_NATIVE_CONSOLE, {
+            execute: () => this.openTerminalExternal()
+        });
+    }
+
+    registerKeybindings(keybindings: KeybindingRegistry): void {
+        keybindings.registerKeybinding({
+            command: TerminalExternalCommands.OPEN_NATIVE_CONSOLE.id,
+            keybinding: 'shift+ctrlcmd+c'
+        });
+    }
+
+    /**
+     * Open native console on host machine.
+     */
+    protected async openTerminalExternal(): Promise<void> {
+        const configuration = this.getTerminalExternalConfiguration();
+
+        // Multi-root workspace opened.
+        if (this.workspaceService.isMultiRootWorkspaceOpened) {
+            // Display a quick pick to let users choose which workspace to spawn the terminal.
+            const chosenWorkspaceRoot = await this.selectTerminalExternalCwd();
+            if (chosenWorkspaceRoot) {
+                await this.terminalExternalService.openTerminal(configuration, chosenWorkspaceRoot);
+            }
+            return;
+        }
+
+        // Only one workspace opened.
+        if (this.workspaceService.opened) {
+            // Spawn the terminal at the root of the current workspace.
+            const workspaceRootUri = this.workspaceService.tryGetRoots()[0].resource;
+            await this.terminalExternalService.openTerminal(configuration, workspaceRootUri.toString());
+            return;
+        }
+
+        // No workspaces opened.
+        const activeEditorUri = this.editorManager.activeEditor?.editor.uri;
+        if (activeEditorUri) {
+            // Spawn external terminal at the parent folder of active editor file.
+            await this.terminalExternalService.openTerminal(configuration, activeEditorUri.parent.toString());
+        } else {
+            // Spawn external terminal at user home directory if no workspaces opened and no current active editor.
+            const userHomeDir = await this.envVariablesServer.getHomeDirUri();
+            await this.terminalExternalService.openTerminal(configuration, userHomeDir);
+        }
+    }
+
+    /**
+     * Get the external terminal configurations from preferences.
+     */
+    protected getTerminalExternalConfiguration(): TerminalExternalConfiguration {
+        return {
+            'terminal.external.linuxExec': this.terminalExternalPreferences['terminal.external.linuxExec'],
+            'terminal.external.osxExec': this.terminalExternalPreferences['terminal.external.osxExec'],
+            'terminal.external.windowsExec': this.terminalExternalPreferences['terminal.external.windowsExec']
+        };
+    }
+
+    /**
+     * Display a quick pick for user to choose a target workspace in opened workspaces.
+     */
+    protected async selectTerminalExternalCwd(): Promise<string | undefined> {
+        const roots = this.workspaceService.tryGetRoots();
+        return this.quickPickService.show(roots.map(
+            ({ resource }) => ({
+                label: this.labelProvider.getName(resource),
+                description: this.labelProvider.getLongName(resource),
+                value: resource.toString()
+            })
+        ), { placeholder: 'Select current working directory for new external terminal' });
+    }
+}

--- a/packages/terminal-external/src/electron-browser/terminal-external-contribution.ts
+++ b/packages/terminal-external/src/electron-browser/terminal-external-contribution.ts
@@ -14,17 +14,18 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { injectable, inject } from 'inversify';
+import { inject, injectable } from 'inversify';
 import {
+    Command,
     CommandContribution,
-    CommandRegistry,
-    Command
+    CommandRegistry
 } from '@theia/core/lib/common';
 import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import { isWindows, isOSX } from '@theia/core/lib/common/os';
 import { QuickPickService } from '@theia/core/lib/common/quick-pick-service';
 import {
     FrontendApplication,
+    FrontendApplicationContribution,
     KeybindingContribution,
     KeybindingRegistry,
     LabelProvider,
@@ -44,7 +45,7 @@ export namespace TerminalExternalCommands {
 }
 
 @injectable()
-export class TerminalExternalFrontendContribution implements CommandContribution, KeybindingContribution {
+export class TerminalExternalFrontendContribution implements FrontendApplicationContribution, CommandContribution, KeybindingContribution {
 
     @inject(EditorManager)
     private readonly editorManager: EditorManager;

--- a/packages/terminal-external/src/electron-browser/terminal-external-frontend-module.ts
+++ b/packages/terminal-external/src/electron-browser/terminal-external-frontend-module.ts
@@ -16,9 +16,13 @@
 
 import { ContainerModule, interfaces } from 'inversify';
 import { CommandContribution } from '@theia/core/lib/common';
-import { FrontendApplicationContribution, KeybindingContribution, WebSocketConnectionProvider } from '@theia/core/lib/browser';
-import { TerminalExternalFrontendContribution } from './terminal-external-contribution';
+import {
+    FrontendApplicationContribution,
+    KeybindingContribution,
+    WebSocketConnectionProvider
+} from '@theia/core/lib/browser';
 import { bindTerminalExternalPreferences } from './terminal-external-preference';
+import { TerminalExternalFrontendContribution } from './terminal-external-contribution';
 import { TerminalExternalService, terminalExternalServicePath } from '../common/terminal-external';
 
 export default new ContainerModule((bind: interfaces.Bind) => {

--- a/packages/terminal-external/src/electron-browser/terminal-external-frontend-module.ts
+++ b/packages/terminal-external/src/electron-browser/terminal-external-frontend-module.ts
@@ -27,7 +27,9 @@ import { TerminalExternalService, terminalExternalServicePath } from '../common/
 
 export default new ContainerModule((bind: interfaces.Bind) => {
     bind(TerminalExternalFrontendContribution).toSelf().inSingletonScope();
+
     bind(FrontendApplicationContribution).toService(TerminalExternalFrontendContribution);
+
     [CommandContribution, KeybindingContribution].forEach(serviceIdentifier =>
         bind(serviceIdentifier).toService(TerminalExternalFrontendContribution)
     );

--- a/packages/terminal-external/src/electron-browser/terminal-external-frontend-module.ts
+++ b/packages/terminal-external/src/electron-browser/terminal-external-frontend-module.ts
@@ -16,13 +16,14 @@
 
 import { ContainerModule, interfaces } from 'inversify';
 import { CommandContribution } from '@theia/core/lib/common';
-import { KeybindingContribution, WebSocketConnectionProvider } from '@theia/core/lib/browser';
+import { FrontendApplicationContribution, KeybindingContribution, WebSocketConnectionProvider } from '@theia/core/lib/browser';
 import { TerminalExternalFrontendContribution } from './terminal-external-contribution';
 import { bindTerminalExternalPreferences } from './terminal-external-preference';
 import { TerminalExternalService, terminalExternalServicePath } from '../common/terminal-external';
 
 export default new ContainerModule((bind: interfaces.Bind) => {
     bind(TerminalExternalFrontendContribution).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).toService(TerminalExternalFrontendContribution);
     [CommandContribution, KeybindingContribution].forEach(serviceIdentifier =>
         bind(serviceIdentifier).toService(TerminalExternalFrontendContribution)
     );

--- a/packages/terminal-external/src/electron-browser/terminal-external-frontend-module.ts
+++ b/packages/terminal-external/src/electron-browser/terminal-external-frontend-module.ts
@@ -1,0 +1,35 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { ContainerModule, interfaces } from 'inversify';
+import { CommandContribution } from '@theia/core/lib/common';
+import { KeybindingContribution, WebSocketConnectionProvider } from '@theia/core/lib/browser';
+import { TerminalExternalFrontendContribution } from './terminal-external-contribution';
+import { bindTerminalExternalPreferences } from './terminal-external-preference';
+import { TerminalExternalService, terminalExternalServicePath } from '../common/terminal-external';
+
+export default new ContainerModule((bind: interfaces.Bind) => {
+    bind(TerminalExternalFrontendContribution).toSelf().inSingletonScope();
+    [CommandContribution, KeybindingContribution].forEach(serviceIdentifier =>
+        bind(serviceIdentifier).toService(TerminalExternalFrontendContribution)
+    );
+
+    bindTerminalExternalPreferences(bind);
+
+    bind(TerminalExternalService).toDynamicValue(ctx =>
+        WebSocketConnectionProvider.createProxy<TerminalExternalService>(ctx.container, terminalExternalServicePath)
+    ).inSingletonScope();
+});

--- a/packages/terminal-external/src/electron-browser/terminal-external-preference.ts
+++ b/packages/terminal-external/src/electron-browser/terminal-external-preference.ts
@@ -1,0 +1,66 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { interfaces } from 'inversify';
+import {
+    createPreferenceProxy,
+    PreferenceProxy,
+    PreferenceSchema,
+    PreferenceService,
+    PreferenceContribution
+} from '@theia/core/lib/browser';
+import { TerminalExternalConfiguration } from '../common/terminal-external';
+
+// The default terminal paths to be displayed on preferences.
+const defaultTerminalLinux = 'x-terminal-emulator';
+const defaultTerminalOSX = 'Terminal.app';
+const defaultTerminalWindows = 'C:\\WINDOWS\\System32\\cmd.exe';
+
+export const TerminalExternalConfigSchema: PreferenceSchema = {
+    type: 'object',
+    properties: {
+        'terminal.external.windowsExec': {
+            type: 'string',
+            description: 'Customizes which terminal to run on Windows.',
+            default: defaultTerminalWindows
+        },
+        'terminal.external.osxExec': {
+            type: 'string',
+            description: 'Customizes which terminal application to run on macOS.',
+            default: defaultTerminalOSX
+        },
+        'terminal.external.linuxExec': {
+            type: 'string',
+            description: 'Customizes which terminal to run on Linux.',
+            default: defaultTerminalLinux
+        }
+    }
+};
+
+export const TerminalExternalPreferences = Symbol('TerminalExternalPreferences');
+export type TerminalExternalPreferences = PreferenceProxy<TerminalExternalConfiguration>;
+
+export function createTerminalExternalPreferences(preferences: PreferenceService): TerminalExternalPreferences {
+    return createPreferenceProxy(preferences, TerminalExternalConfigSchema);
+}
+
+export function bindTerminalExternalPreferences(bind: interfaces.Bind): void {
+    bind(TerminalExternalPreferences).toDynamicValue(ctx => {
+        const preferences = ctx.container.get<PreferenceService>(PreferenceService);
+        return createTerminalExternalPreferences(preferences);
+    });
+    bind(PreferenceContribution).toConstantValue({ schema: TerminalExternalConfigSchema });
+}

--- a/packages/terminal-external/src/electron-browser/terminal-external-preference.ts
+++ b/packages/terminal-external/src/electron-browser/terminal-external-preference.ts
@@ -19,6 +19,7 @@ import {
     createPreferenceProxy,
     PreferenceProxy,
     PreferenceSchema,
+    PreferenceScope,
     PreferenceService,
     PreferenceContribution
 } from '@theia/core/lib/browser';
@@ -80,11 +81,11 @@ export class TerminalExternalPreferencesService {
     async setHostPreferenceExec(): Promise<void> {
         const hostExec = await this.terminalExternalService.getDefaultExec();
         if (isWindows) {
-            await this.preferences.set('terminal.external.windowsExec', hostExec);
+            await this.preferences.set('terminal.external.windowsExec', hostExec, PreferenceScope.Default);
         } else if (isOSX) {
-            await this.preferences.set('terminal.external.osxExec', hostExec);
+            await this.preferences.set('terminal.external.osxExec', hostExec, PreferenceScope.Default);
         } else {
-            await this.preferences.set('terminal.external.linuxExec', hostExec);
+            await this.preferences.set('terminal.external.linuxExec', hostExec, PreferenceScope.Default);
         }
     }
 

--- a/packages/terminal-external/src/electron-browser/terminal-external-preference.ts
+++ b/packages/terminal-external/src/electron-browser/terminal-external-preference.ts
@@ -25,7 +25,7 @@ import {
 import { TerminalExternalConfiguration } from '../common/terminal-external';
 
 // The default terminal paths to be displayed on preferences.
-const defaultTerminalLinux = 'x-terminal-emulator';
+const defaultTerminalLinux = 'xterm';
 const defaultTerminalOSX = 'Terminal.app';
 const defaultTerminalWindows = 'C:\\WINDOWS\\System32\\cmd.exe';
 

--- a/packages/terminal-external/src/electron-browser/terminal-external-preference.ts
+++ b/packages/terminal-external/src/electron-browser/terminal-external-preference.ts
@@ -24,28 +24,23 @@ import {
 } from '@theia/core/lib/browser';
 import { TerminalExternalConfiguration } from '../common/terminal-external';
 
-// The default terminal paths to be displayed on preferences.
-const defaultTerminalLinux = 'xterm';
-const defaultTerminalOSX = 'Terminal.app';
-const defaultTerminalWindows = 'C:\\WINDOWS\\System32\\cmd.exe';
-
 export const TerminalExternalConfigSchema: PreferenceSchema = {
     type: 'object',
     properties: {
         'terminal.external.windowsExec': {
             type: 'string',
             description: 'Customizes which terminal to run on Windows.',
-            default: defaultTerminalWindows
+            default: 'C:\\WINDOWS\\System32\\cmd.exe'
         },
         'terminal.external.osxExec': {
             type: 'string',
             description: 'Customizes which terminal application to run on macOS.',
-            default: defaultTerminalOSX
+            default: 'Terminal.app'
         },
         'terminal.external.linuxExec': {
             type: 'string',
             description: 'Customizes which terminal to run on Linux.',
-            default: defaultTerminalLinux
+            default: 'xterm'
         }
     }
 };

--- a/packages/terminal-external/src/electron-node/terminal-external-backend-module.ts
+++ b/packages/terminal-external/src/electron-node/terminal-external-backend-module.ts
@@ -17,8 +17,12 @@
 import { ContainerModule, interfaces } from 'inversify';
 import { ConnectionHandler, JsonRpcConnectionHandler } from '@theia/core/lib/common';
 import { isWindows, isOSX } from '@theia/core/lib/common/os';
+import {
+    WindowsTerminalExternalService,
+    MacTerminalExternalService,
+    LinuxTerminalExternalService
+} from './terminal-external-service';
 import { TerminalExternalService, terminalExternalServicePath } from '../common/terminal-external';
-import { WindowsTerminalExternalService, MacTerminalExternalService, LinuxTerminalExternalService } from './terminal-external-service';
 
 export function bindTerminalExternalService(bind: interfaces.Bind): void {
     if (isWindows) {

--- a/packages/terminal-external/src/electron-node/terminal-external-backend-module.ts
+++ b/packages/terminal-external/src/electron-node/terminal-external-backend-module.ts
@@ -1,0 +1,44 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { ContainerModule, interfaces } from 'inversify';
+import { ConnectionHandler, JsonRpcConnectionHandler } from '@theia/core/lib/common';
+import { isWindows, isOSX } from '@theia/core/lib/common/os';
+import { TerminalExternalService, terminalExternalServicePath } from '../common/terminal-external';
+import { WindowsTerminalExternalService, MacTerminalExternalService, LinuxTerminalExternalService } from './terminal-external-service';
+
+export function bindTerminalExternalService(bind: interfaces.Bind): void {
+    if (isWindows) {
+        bind(WindowsTerminalExternalService).toSelf().inSingletonScope();
+        bind(TerminalExternalService).toService(WindowsTerminalExternalService);
+    } else if (isOSX) {
+        bind(MacTerminalExternalService).toSelf().inSingletonScope();
+        bind(TerminalExternalService).toService(MacTerminalExternalService);
+    } else {
+        bind(LinuxTerminalExternalService).toSelf().inSingletonScope();
+        bind(TerminalExternalService).toService(LinuxTerminalExternalService);
+    }
+
+    bind(ConnectionHandler).toDynamicValue(ctx =>
+        new JsonRpcConnectionHandler(terminalExternalServicePath, () =>
+            ctx.container.get(TerminalExternalService)
+        )
+    ).inSingletonScope();
+}
+
+export default new ContainerModule(bind => {
+    bindTerminalExternalService(bind);
+});

--- a/packages/terminal-external/src/electron-node/terminal-external-service.ts
+++ b/packages/terminal-external/src/electron-node/terminal-external-service.ts
@@ -77,6 +77,10 @@ export class WindowsTerminalExternalService implements TerminalExternalService {
         });
     }
 
+    async getDefaultExec(): Promise<string> {
+        return WindowsTerminalExternalService.getDefaultTerminalWindows();
+    }
+
     /**
      * Get the default terminal app on Windows.
      * (determine and initialize the variable if not found).
@@ -122,6 +126,10 @@ export class MacTerminalExternalService implements TerminalExternalService {
         });
     }
 
+    async getDefaultExec(): Promise<string> {
+        return MacTerminalExternalService.getDefaultTerminalOSX();
+    }
+
     /**
      * Get the default terminal app on OSX.
      */
@@ -150,6 +158,10 @@ export class LinuxTerminalExternalService implements TerminalExternalService {
                 child.on('exit', () => c());
             });
         });
+    }
+
+    async getDefaultExec(): Promise<string> {
+        return LinuxTerminalExternalService.getDefaultTerminalLinux();
     }
 
     /**

--- a/packages/terminal-external/src/electron-node/terminal-external-service.ts
+++ b/packages/terminal-external/src/electron-node/terminal-external-service.ts
@@ -88,8 +88,7 @@ export class WindowsTerminalExternalService implements TerminalExternalService {
     public static getDefaultTerminalWindows(): string {
         if (!WindowsTerminalExternalService.DEFAULT_TERMINAL_WINDOWS) {
             const isWoW64 = !!process.env.hasOwnProperty('PROCESSOR_ARCHITEW6432');
-            WindowsTerminalExternalService.DEFAULT_TERMINAL_WINDOWS = `${process.env.windir ? process.env.windir : 'C:\\Windows'}\\
-            ${isWoW64 ? 'Sysnative' : 'System32'}\\cmd.exe`;
+            WindowsTerminalExternalService.DEFAULT_TERMINAL_WINDOWS = `${process.env.windir ? process.env.windir : 'C:\\Windows'}\\${isWoW64 ? 'Sysnative' : 'System32'}\\cmd.exe`;
         }
         return WindowsTerminalExternalService.DEFAULT_TERMINAL_WINDOWS;
     }

--- a/packages/terminal-external/src/electron-node/terminal-external-service.ts
+++ b/packages/terminal-external/src/electron-node/terminal-external-service.ts
@@ -1,0 +1,182 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as cp from 'child_process';
+import * as path from 'path';
+import * as fs from 'fs-extra';
+import { injectable } from 'inversify';
+import { OS } from '@theia/core/lib/common/os';
+import { FileUri } from '@theia/core/lib/node/file-uri';
+import { TerminalExternalService, TerminalExternalConfiguration } from '../common/terminal-external';
+
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+// some code copied and modified from https://github.com/microsoft/vscode/blob/1.52.1/src/vs/workbench/contrib/externalTerminal/node/externalTerminalService.ts
+
+@injectable()
+export class WindowsTerminalExternalService implements TerminalExternalService {
+    private static readonly CMD = 'cmd.exe';
+
+    private static DEFAULT_TERMINAL_WINDOWS: string;
+
+    async openTerminal(configuration: TerminalExternalConfiguration, cwd: string): Promise<void> {
+        await this.spawnTerminal(configuration, FileUri.fsPath(cwd));
+    }
+
+    private async spawnTerminal(configuration: TerminalExternalConfiguration, cwd?: string): Promise<void> {
+        const terminalConfig = configuration['terminal.external.windowsExec'];
+        const exec = terminalConfig || WindowsTerminalExternalService.getDefaultTerminalWindows();
+
+        // Make the drive letter uppercase on Windows (https://github.com/microsoft/vscode/issues/9448).
+        if (cwd && cwd[1] === ':') {
+            cwd = cwd[0].toUpperCase() + cwd.substr(1);
+        }
+
+        // cmder ignores the environment cwd and instead opts to always open in %USERPROFILE%
+        // unless otherwise specified.
+        const basename = path.basename(exec).toLowerCase();
+        if (basename === 'cmder' || basename === 'cmder.exe') {
+            cp.spawn(exec, cwd ? [cwd] : undefined);
+            return;
+        }
+
+        const cmdArgs = ['/c', 'start', '/wait'];
+        // The "" argument is the window title. Without this, exec doesn't work when the path contains spaces.
+        if (exec.indexOf(' ') >= 0) {
+            cmdArgs.push('""');
+        }
+
+        cmdArgs.push(exec);
+
+        // Add starting directory parameter for Windows Terminal app.
+        if (basename === 'wt' || basename === 'wt.exe') {
+            cmdArgs.push('-d .');
+        }
+
+        return new Promise<void>(async (c, e) => {
+            const env = cwd ? { cwd } : undefined;
+            const command = this.getWindowsShell();
+            const child = cp.spawn(command, cmdArgs, env);
+            child.on('error', e);
+            child.on('exit', () => c());
+        });
+    }
+
+    /**
+     * Get the default terminal app on Windows.
+     * (determine and initialize the variable if not found).
+     */
+    public static getDefaultTerminalWindows(): string {
+        if (!WindowsTerminalExternalService.DEFAULT_TERMINAL_WINDOWS) {
+            const isWoW64 = !!process.env.hasOwnProperty('PROCESSOR_ARCHITEW6432');
+            WindowsTerminalExternalService.DEFAULT_TERMINAL_WINDOWS = `${process.env.windir ? process.env.windir : 'C:\\Windows'}\\
+            ${isWoW64 ? 'Sysnative' : 'System32'}\\cmd.exe`;
+        }
+        return WindowsTerminalExternalService.DEFAULT_TERMINAL_WINDOWS;
+    }
+
+    /**
+     * Find the Windows Shell process to start up (default to cmd.exe).
+     */
+    private getWindowsShell(): string {
+        // Find the path to cmd.exe if possible (%compsec% environment variable).
+        return process.env.compsec || WindowsTerminalExternalService.CMD;
+    }
+}
+
+@injectable()
+export class MacTerminalExternalService implements TerminalExternalService {
+    private static osxOpener = '/usr/bin/open';
+    private static defaultTerminalApp = 'Terminal.app';
+
+    async openTerminal(configuration: TerminalExternalConfiguration, cwd: string): Promise<void> {
+        await this.spawnTerminal(configuration, FileUri.fsPath(cwd));
+    }
+
+    private async spawnTerminal(configuration: TerminalExternalConfiguration, cwd?: string): Promise<void> {
+        const terminalConfig = configuration['terminal.external.osxExec'];
+        const terminalApp = terminalConfig || MacTerminalExternalService.getDefaultTerminalOSX();
+        return new Promise<void>((c, e) => {
+            const args = ['-a', terminalApp];
+            if (cwd) {
+                args.push(cwd);
+            }
+            const child = cp.spawn(MacTerminalExternalService.osxOpener, args);
+            child.on('error', e);
+            child.on('exit', () => c());
+        });
+    }
+
+    /**
+     * Get the default terminal app on OSX.
+     */
+    public static getDefaultTerminalOSX(): string {
+        return this.defaultTerminalApp;
+    }
+}
+
+@injectable()
+export class LinuxTerminalExternalService implements TerminalExternalService {
+    private static DEFAULT_TERMINAL_LINUX_READY: Promise<string>;
+
+    async openTerminal(configuration: TerminalExternalConfiguration, cwd: string): Promise<void> {
+        await this.spawnTerminal(configuration, FileUri.fsPath(cwd));
+    }
+
+    private async spawnTerminal(configuration: TerminalExternalConfiguration, cwd?: string): Promise<void> {
+        const terminalConfig = configuration['terminal.external.linuxExec'];
+        const execPromise = terminalConfig ? Promise.resolve(terminalConfig) : LinuxTerminalExternalService.getDefaultTerminalLinux();
+
+        return new Promise<void>((c, e) => {
+            execPromise.then(exec => {
+                const env = cwd ? { cwd } : undefined;
+                const child = cp.spawn(exec, [], env);
+                child.on('error', e);
+                child.on('exit', () => c());
+            });
+        });
+    }
+
+    /**
+     * Get the default terminal app on Linux.
+     * (determine and initialize the variable based on desktop environment if not found)
+     */
+    public static async getDefaultTerminalLinux(): Promise<string> {
+        if (!LinuxTerminalExternalService.DEFAULT_TERMINAL_LINUX_READY) {
+            LinuxTerminalExternalService.DEFAULT_TERMINAL_LINUX_READY = new Promise(async r => {
+                if (OS.type() === OS.Type.Linux) {
+                    const isDebian = await fs.pathExists('etc/debian_version');
+                    if (isDebian) {
+                        r('x-terminal-emulator');
+                    } else if (process.env.DESKTOP_SESSION === 'gnome' || process.env.DESKTOP_SESSION === 'gnome-classic') {
+                        r('gnome-terminal');
+                    } else if (process.env.DESKTOP_SESSION === 'kde-plasma') {
+                        r('konsole');
+                    } else if (process.env.COLORTERM) {
+                        r(process.env.COLORTERM);
+                    } else {
+                        r('xterm');
+                    }
+                } else {
+                    r('xterm');
+                }
+            });
+        }
+        return LinuxTerminalExternalService.DEFAULT_TERMINAL_LINUX_READY;
+    }
+}

--- a/packages/terminal-external/src/package.spec.ts
+++ b/packages/terminal-external/src/package.spec.ts
@@ -1,0 +1,29 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+/* note: this bogus test file is required so that
+  we are able to run mocha unit tests on this
+  package, without having any actual unit tests in it.
+  This way a coverage report will be generated,
+  showing 0% coverage, instead of no report.
+  This file can be removed once we have real unit
+  tests in place. */
+
+describe('terminal-external package', () => {
+
+    it('support code coverage statistics', () => true);
+
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -171,6 +171,9 @@
       ],
       "@theia/timeline/*": [
         "packages/timeline/*"
+      ],
+      "@theia/terminal-external/lib/*": [
+        "packages/terminal-external/src/*"
       ]
     }
   }


### PR DESCRIPTION
+ Add new extension `terminal-external`
+ Add support for `Open New External Terminal` command

- [ ] Add dynamic preference

- [ ] Test on Windows
- [ ] Test on MacOS
- [ ] Test on Linux

Signed-off-by: Duc Nguyen <duc.a.nguyen@ericsson.com>


