### PR TITLE
Initial contribution of @theia/terminal-external

### DIFF
--- a/configs/root-compilation.tsconfig.json
+++ b/configs/root-compilation.tsconfig.json
@@ -116,6 +116,9 @@
       "path": "../packages/terminal/compile.tsconfig.json"
     },
     {
+      "path": "../packages/terminal-external/compile.tsconfig.json"
+    },
+    {
       "path": "../packages/typehierarchy/compile.tsconfig.json"
     },
     {

--- a/examples/electron/compile.tsconfig.json
+++ b/examples/electron/compile.tsconfig.json
@@ -108,6 +108,9 @@
       "path": "../../packages/terminal/compile.tsconfig.json"
     },
     {
+      "path": "../../packages/terminal-external/compile.tsconfig.json"
+    },
+    {
       "path": "../../packages/typehierarchy/compile.tsconfig.json"
     },
     {

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -48,6 +48,7 @@
     "@theia/search-in-workspace": "1.11.0",
     "@theia/task": "1.11.0",
     "@theia/terminal": "1.11.0",
+    "@theia/terminal-external": "1.11.0",
     "@theia/timeline": "1.11.0",
     "@theia/typehierarchy": "1.11.0",
     "@theia/userstorage": "1.11.0",

--- a/packages/core/src/browser/preferences/preference-proxy.spec.ts
+++ b/packages/core/src/browser/preferences/preference-proxy.spec.ts
@@ -73,167 +73,232 @@ describe('Preference Proxy', () => {
         getProvider(PreferenceScope.User).markReady();
         getProvider(PreferenceScope.Workspace).markReady();
         getProvider(PreferenceScope.Folder).markReady();
-        console.log('before ready');
         try {
             await prefService.ready;
         } catch (e) {
             console.error(e);
         }
-        console.log('done');
     });
 
     afterEach(() => {
     });
 
+    // Actually run the test suite with different parameters:
+    testPreferenceProxy('Synchronous Schema Definition', { asyncSchema: false });
+    testPreferenceProxy('Asynchronous Schema Definition (1s delay)', { asyncSchema: true });
+
     function getProvider(scope: PreferenceScope): MockPreferenceProvider {
         return testContainer.getNamed(PreferenceProvider, scope) as MockPreferenceProvider;
     }
 
-    function getProxy(schema?: PreferenceSchema, options?: PreferenceProxyOptions): PreferenceProxy<{ [key: string]: any }> {
-        const s: PreferenceSchema = schema || {
-            properties: {
-                'my.pref': {
-                    type: 'string',
-                    defaultValue: 'foo'
-                }
-            }
-        };
-        prefSchema.setSchema(s);
-        return createPreferenceProxy(prefService, s, options);
-    }
+    function testPreferenceProxy(testDescription: string, testOptions: { asyncSchema: boolean }): void {
 
-    it('by default, it should get provide access in flat style but not deep', () => {
-        const proxy = getProxy();
-        expect(proxy['my.pref']).to.equal('foo');
-        expect(proxy.my).to.equal(undefined);
-        expect(Object.keys(proxy).join()).to.equal(['my.pref'].join());
-    });
+        describe(testDescription, () => {
 
-    it('it should get provide access in deep style but not flat', () => {
-        const proxy = getProxy(undefined, { style: 'deep' });
-        expect(proxy['my.pref']).to.equal(undefined);
-        expect(proxy.my.pref).to.equal('foo');
-        expect(Object.keys(proxy).join()).to.equal(['my'].join());
-    });
-
-    it('it should get provide access in to both styles', () => {
-        const proxy = getProxy(undefined, { style: 'both' });
-        expect(proxy['my.pref']).to.equal('foo');
-        expect(proxy.my.pref).to.equal('foo');
-        expect(Object.keys(proxy).join()).to.equal(['my', 'my.pref'].join());
-    });
-
-    it('it should forward change events', async () => {
-        const proxy = getProxy(undefined, { style: 'both' });
-        let theChange: PreferenceChangeEvent<{ [key: string]: any }>;
-        proxy.onPreferenceChanged(change => {
-            expect(theChange).to.equal(undefined);
-            theChange = change;
-        });
-        let theSecondChange: PreferenceChangeEvent<{ [key: string]: any }>;
-        (proxy.my as PreferenceProxy<{ [key: string]: any }>).onPreferenceChanged(change => {
-            expect(theSecondChange).to.equal(undefined);
-            theSecondChange = change;
-        });
-
-        await getProvider(PreferenceScope.User).setPreference('my.pref', 'bar');
-
-        expect(theChange!.newValue).to.equal('bar');
-        expect(theChange!.oldValue).to.equal(undefined);
-        expect(theChange!.preferenceName).to.equal('my.pref');
-        expect(theSecondChange!.newValue).to.equal('bar');
-        expect(theSecondChange!.oldValue).to.equal(undefined);
-        expect(theSecondChange!.preferenceName).to.equal('my.pref');
-    });
-
-    it('toJSON with deep', () => {
-        const proxy = getProxy({
-            properties: {
-                'foo.baz': {
-                    type: 'number',
-                    default: 4
-                },
-                'foo.bar.x': {
-                    type: 'boolean',
-                    default: true
-                },
-                'foo.bar.y': {
-                    type: 'boolean',
-                    default: false
-                },
-                'a': {
-                    type: 'string',
-                    default: 'a'
-                }
-            }
-        }, { style: 'deep' });
-        assert.deepStrictEqual(JSON.stringify(proxy, undefined, 2), JSON.stringify({
-            foo: {
-                baz: 4,
-                bar: {
-                    x: true,
-                    y: false
-                }
-            },
-            a: 'a'
-        }, undefined, 2), 'there should not be foo.bar.x to avoid sending excessive data to remote clients');
-    });
-
-    it('get nested default', () => {
-        const proxy = getProxy({
-            properties: {
-                'foo': {
-                    'anyOf': [
-                        {
-                            'enum': [
-                                false
-                            ]
-                        },
-                        {
-                            'properties': {
-                                'bar': {
-                                    'anyOf': [
-                                        {
-                                            'enum': [
-                                                false
-                                            ]
-                                        },
-                                        {
-                                            'properties': {
-                                                'x': {
-                                                    type: 'boolean'
-                                                },
-                                                'y': {
-                                                    type: 'boolean'
-                                                }
-                                            }
-                                        }
-                                    ]
-                                }
-                            }
+            function getProxy(schema?: PreferenceSchema, options?: PreferenceProxyOptions): {
+                proxy: PreferenceProxy<{ [key: string]: any }>,
+                /** Only set if we are using a schema asynchronously. */
+                promisedSchema?: Promise<PreferenceSchema>
+            } {
+                const s: PreferenceSchema = schema || {
+                    properties: {
+                        'my.pref': {
+                            type: 'string',
+                            defaultValue: 'foo'
                         }
-                    ],
-                    default: {
+                    }
+                };
+                if (testOptions.asyncSchema) {
+                    const promisedSchema = new Promise<PreferenceSchema>(resolve => setTimeout(() => {
+                        prefSchema.setSchema(s);
+                        resolve(s);
+                    }, 1000));
+                    const proxy = createPreferenceProxy(prefService, promisedSchema, options);
+                    return { proxy, promisedSchema };
+                } else {
+                    prefSchema.setSchema(s);
+                    const proxy = createPreferenceProxy(prefService, s, options);
+                    return { proxy };
+                }
+            }
+
+            if (testOptions.asyncSchema) {
+                it('using the proxy before the schema is set should be no-op', async () => {
+                    const { proxy, promisedSchema } = getProxy();
+                    let changed = 0;
+                    proxy.onPreferenceChanged(event => {
+                        changed += 1;
+                    });
+                    expect(proxy['my.pref']).to.equal(undefined);
+                    expect(Object.keys(proxy).length).to.equal(0);
+                    // The proxy doesn't know the schema, so events shouldn't be forwarded:
+                    await getProvider(PreferenceScope.User).setPreference('my.pref', 'bar');
+                    expect(changed).to.equal(0);
+                    expect(proxy['my.pref']).to.equal(undefined);
+                    expect(Object.keys(proxy).length).to.equal(0);
+                    // Once the schema is resolved, operations should be working:
+                    await promisedSchema!;
+                    expect(proxy['my.pref']).to.equal('bar');
+                    expect(Object.keys(proxy)).members(['my.pref']);
+                    await getProvider(PreferenceScope.User).setPreference('my.pref', 'fizz');
+                    expect(changed).to.equal(1);
+                    expect(proxy['my.pref']).to.equal('fizz');
+
+                });
+            }
+
+            it('by default, it should get provide access in flat style but not deep', async () => {
+                const { proxy, promisedSchema } = getProxy();
+                if (promisedSchema) {
+                    await promisedSchema;
+                }
+                expect(proxy['my.pref']).to.equal('foo');
+                expect(proxy.my).to.equal(undefined);
+                expect(Object.keys(proxy).join()).to.equal(['my.pref'].join());
+            });
+
+            it('it should get provide access in deep style but not flat', async () => {
+                const { proxy, promisedSchema } = getProxy(undefined, { style: 'deep' });
+                if (promisedSchema) {
+                    await promisedSchema;
+                }
+                expect(proxy['my.pref']).to.equal(undefined);
+                expect(proxy.my.pref).to.equal('foo');
+                expect(Object.keys(proxy).join()).to.equal(['my'].join());
+            });
+
+            it('it should get provide access in to both styles', async () => {
+                const { proxy, promisedSchema } = getProxy(undefined, { style: 'both' });
+                if (promisedSchema) {
+                    await promisedSchema;
+                }
+                expect(proxy['my.pref']).to.equal('foo');
+                expect(proxy.my.pref).to.equal('foo');
+                expect(Object.keys(proxy).join()).to.equal(['my', 'my.pref'].join());
+            });
+
+            it('it should forward change events', async () => {
+                const { proxy, promisedSchema } = getProxy(undefined, { style: 'both' });
+                if (promisedSchema) {
+                    await promisedSchema;
+                }
+                let theChange: PreferenceChangeEvent<{ [key: string]: any }>;
+                proxy.onPreferenceChanged(change => {
+                    expect(theChange).to.equal(undefined);
+                    theChange = change;
+                });
+                let theSecondChange: PreferenceChangeEvent<{ [key: string]: any }>;
+                (proxy.my as PreferenceProxy<{ [key: string]: any }>).onPreferenceChanged(change => {
+                    expect(theSecondChange).to.equal(undefined);
+                    theSecondChange = change;
+                });
+
+                await getProvider(PreferenceScope.User).setPreference('my.pref', 'bar');
+
+                expect(theChange!.newValue).to.equal('bar');
+                expect(theChange!.oldValue).to.equal(undefined);
+                expect(theChange!.preferenceName).to.equal('my.pref');
+                expect(theSecondChange!.newValue).to.equal('bar');
+                expect(theSecondChange!.oldValue).to.equal(undefined);
+                expect(theSecondChange!.preferenceName).to.equal('my.pref');
+            });
+
+            it('toJSON with deep', async () => {
+                const { proxy, promisedSchema } = getProxy({
+                    properties: {
+                        'foo.baz': {
+                            type: 'number',
+                            default: 4
+                        },
+                        'foo.bar.x': {
+                            type: 'boolean',
+                            default: true
+                        },
+                        'foo.bar.y': {
+                            type: 'boolean',
+                            default: false
+                        },
+                        'a': {
+                            type: 'string',
+                            default: 'a'
+                        }
+                    }
+                }, { style: 'deep' });
+                if (promisedSchema) {
+                    await promisedSchema;
+                }
+                assert.deepStrictEqual(JSON.stringify(proxy, undefined, 2), JSON.stringify({
+                    foo: {
+                        baz: 4,
                         bar: {
                             x: true,
                             y: false
                         }
+                    },
+                    a: 'a'
+                }, undefined, 2), 'there should not be foo.bar.x to avoid sending excessive data to remote clients');
+            });
+
+            it('get nested default', async () => {
+                const { proxy, promisedSchema } = getProxy({
+                    properties: {
+                        'foo': {
+                            'anyOf': [
+                                {
+                                    'enum': [
+                                        false
+                                    ]
+                                },
+                                {
+                                    'properties': {
+                                        'bar': {
+                                            'anyOf': [
+                                                {
+                                                    'enum': [
+                                                        false
+                                                    ]
+                                                },
+                                                {
+                                                    'properties': {
+                                                        'x': {
+                                                            type: 'boolean'
+                                                        },
+                                                        'y': {
+                                                            type: 'boolean'
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            ],
+                            default: {
+                                bar: {
+                                    x: true,
+                                    y: false
+                                }
+                            }
+                        }
                     }
+                }, { style: 'both' });
+                if (promisedSchema) {
+                    await promisedSchema;
                 }
-            }
-        }, { style: 'both' });
-        assert.deepStrictEqual(proxy['foo'], {
-            bar: {
-                x: true,
-                y: false
-            }
+                assert.deepStrictEqual(proxy['foo'], {
+                    bar: {
+                        x: true,
+                        y: false
+                    }
+                });
+                assert.deepStrictEqual(proxy['foo.bar'], {
+                    x: true,
+                    y: false
+                });
+                assert.strictEqual(proxy['foo.bar.x'], true);
+                assert.strictEqual(proxy['foo.bar.y'], false);
+            });
         });
-        assert.deepStrictEqual(proxy['foo.bar'], {
-            x: true,
-            y: false
-        });
-        assert.strictEqual(proxy['foo.bar.x'], true);
-        assert.strictEqual(proxy['foo.bar.y'], false);
-    });
+    }
 
 });

--- a/packages/terminal-external/.eslintrc.js
+++ b/packages/terminal-external/.eslintrc.js
@@ -1,0 +1,10 @@
+/** @type {import('eslint').Linter.Config} */
+module.exports = {
+    extends: [
+        '../../configs/build.eslintrc.json'
+    ],
+    parserOptions: {
+        tsconfigRootDir: __dirname,
+        project: 'compile.tsconfig.json'
+    }
+};

--- a/packages/terminal-external/README.md
+++ b/packages/terminal-external/README.md
@@ -1,0 +1,32 @@
+<div align='center'>
+
+<br />
+
+<img src='https://raw.githubusercontent.com/eclipse-theia/theia/master/logo/theia.svg?sanitize=true' alt='theia-ext-logo' width='100px' />
+
+<h2>ECLIPSE THEIA - TERMINAL-EXTERNAL EXTENSION</h2>
+
+<hr />
+
+</div>
+
+## Description
+
+The `@theia/terminal-external` extension contributes the ability to spawn external terminals from `electron` applications.
+
+**Note:** The extension does not support browser applications.
+
+## Additional Information
+
+- [Theia - GitHub](https://github.com/eclipse-theia/theia)
+- [Theia - Website](https://theia-ide.org/)
+
+## License
+
+-   [Eclipse Public License 2.0](http://www.eclipse.org/legal/epl-2.0/)
+-   [一 (Secondary) GNU General Public License, version 2 with the GNU Classpath Exception](https://projects.eclipse.org/license/secondary-gpl-2.0-cp)
+
+## Trademark
+
+"Theia" is a trademark of the Eclipse Foundation
+https://www.eclipse.org/theia

--- a/packages/terminal-external/compile.tsconfig.json
+++ b/packages/terminal-external/compile.tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../configs/base.tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": [
+    "src"
+  ],
+  "references": [
+    {
+      "path": "../core/compile.tsconfig.json"
+    },
+    {
+      "path": "../editor/compile.tsconfig.json"
+    },
+    {
+      "path": "../workspace/compile.tsconfig.json"
+    }
+  ]
+}

--- a/packages/terminal-external/package.json
+++ b/packages/terminal-external/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@theia/terminal-external",
+  "version": "1.11.0",
+  "description": "Theia - External Terminal Extension",
+  "dependencies": {
+    "@theia/core": "1.11.0",
+    "@theia/editor": "1.11.0",
+    "@theia/workspace": "1.11.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "theiaExtensions": [
+    {
+      "backendElectron": "lib/electron-node/terminal-external-backend-module",
+      "frontendElectron": "lib/electron-browser/terminal-external-frontend-module"
+    }
+  ],
+  "keywords": [
+    "theia-extension"
+  ],
+  "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/eclipse-theia/theia.git"
+  },
+  "bugs": {
+    "url": "https://github.com/eclipse-theia/theia/issues"
+  },
+  "homepage": "https://github.com/eclipse-theia/theia",
+  "files": [
+    "lib",
+    "src"
+  ],
+  "scripts": {
+    "lint": "theiaext lint",
+    "build": "theiaext build",
+    "watch": "theiaext watch",
+    "clean": "theiaext clean",
+    "test": "theiaext test"
+  },
+  "devDependencies": {
+    "@theia/ext-scripts": "^1.9.0"
+  },
+  "nyc": {
+    "extends": "../../configs/nyc.json"
+  }
+}

--- a/packages/terminal-external/src/common/terminal-external.ts
+++ b/packages/terminal-external/src/common/terminal-external.ts
@@ -1,0 +1,38 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+export const TerminalExternalService = Symbol('TerminalExternalService');
+export const terminalExternalServicePath = '/services/terminal-external';
+
+export interface TerminalExternalConfiguration {
+    'terminal.external.windowsExec': string
+    'terminal.external.osxExec': string
+    'terminal.external.linuxExec': string
+}
+
+export interface TerminalExternalService {
+    /**
+     * Open a native terminal at the current working directory.
+     * @param configuration the configuration for opening external terminals.
+     * @param cwd the current working directory where the terminal should open from.
+     */
+    openTerminal(configuration: TerminalExternalConfiguration, cwd: string): Promise<void>;
+    /**
+     * Determine the default exec of the external terminal.
+     * @returns the default terminal exec.
+     */
+    getDefaultExec(): Promise<string>;
+}

--- a/packages/terminal-external/src/electron-browser/terminal-external-contribution.ts
+++ b/packages/terminal-external/src/electron-browser/terminal-external-contribution.ts
@@ -1,0 +1,126 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { inject, injectable } from 'inversify';
+import {
+    Command,
+    CommandContribution,
+    CommandRegistry
+} from '@theia/core/lib/common';
+import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
+import { QuickPickService } from '@theia/core/lib/common/quick-pick-service';
+import {
+    KeybindingContribution,
+    KeybindingRegistry,
+    LabelProvider
+} from '@theia/core/lib/browser';
+import { EditorManager } from '@theia/editor/lib/browser/editor-manager';
+import { WorkspaceService } from '@theia/workspace/lib/browser';
+import { TerminalExternalService } from '../common/terminal-external';
+import { TerminalExternalPreferenceService } from './terminal-external-preference';
+
+export namespace TerminalExternalCommands {
+    export const OPEN_NATIVE_CONSOLE: Command = {
+        id: 'workbench.action.terminal.openNativeConsole',
+        label: 'Open New External Terminal'
+    };
+}
+
+@injectable()
+export class TerminalExternalFrontendContribution implements CommandContribution, KeybindingContribution {
+
+    @inject(EditorManager)
+    private readonly editorManager: EditorManager;
+
+    @inject(EnvVariablesServer)
+    private readonly envVariablesServer: EnvVariablesServer;
+
+    @inject(LabelProvider)
+    private readonly labelProvider: LabelProvider;
+
+    @inject(QuickPickService)
+    private readonly quickPickService: QuickPickService;
+
+    @inject(TerminalExternalService)
+    private readonly terminalExternalService: TerminalExternalService;
+
+    @inject(TerminalExternalPreferenceService)
+    private readonly terminalExternalPreferences: TerminalExternalPreferenceService;
+
+    @inject(WorkspaceService)
+    private readonly workspaceService: WorkspaceService;
+
+    registerCommands(commands: CommandRegistry): void {
+        commands.registerCommand(TerminalExternalCommands.OPEN_NATIVE_CONSOLE, {
+            execute: async () => this.openTerminalExternal()
+        });
+    }
+
+    registerKeybindings(keybindings: KeybindingRegistry): void {
+        keybindings.registerKeybinding({
+            command: TerminalExternalCommands.OPEN_NATIVE_CONSOLE.id,
+            keybinding: 'shift+ctrlcmd+c'
+        });
+    }
+
+    /**
+     * Open a native console on the host machine.
+     *
+     * If multi-root workspace opened, displays a quick pick to let users choose which workspace to spawn the terminal.
+     * If only one workspace opened, the terminal spawns at the root of the current workspace.
+     * If no workspaces opened and there's an active editor, the terminal spawns at the parent folder of that file.
+     * If no workspaces opened and no active editors, the terminal spawns at user home directory.
+     */
+    protected async openTerminalExternal(): Promise<void> {
+        const configuration = this.terminalExternalPreferences.getTerminalExternalConfiguration();
+
+        if (this.workspaceService.isMultiRootWorkspaceOpened) {
+            const chosenWorkspaceRoot = await this.selectTerminalExternalCwd();
+            if (chosenWorkspaceRoot) {
+                await this.terminalExternalService.openTerminal(configuration, chosenWorkspaceRoot);
+            }
+            return;
+        }
+
+        if (this.workspaceService.opened) {
+            const workspaceRootUri = this.workspaceService.tryGetRoots()[0].resource;
+            await this.terminalExternalService.openTerminal(configuration, workspaceRootUri.toString());
+            return;
+        }
+
+        const activeEditorUri = this.editorManager.activeEditor?.editor.uri;
+        if (activeEditorUri) {
+            await this.terminalExternalService.openTerminal(configuration, activeEditorUri.parent.toString());
+        } else {
+            const userHomeDir = await this.envVariablesServer.getHomeDirUri();
+            await this.terminalExternalService.openTerminal(configuration, userHomeDir);
+        }
+    }
+
+    /**
+     * Display a quick pick for user to choose a target workspace in opened workspaces.
+     */
+    protected async selectTerminalExternalCwd(): Promise<string | undefined> {
+        const roots = this.workspaceService.tryGetRoots();
+        return this.quickPickService.show(roots.map(
+            ({ resource }) => ({
+                label: this.labelProvider.getName(resource),
+                description: this.labelProvider.getLongName(resource),
+                value: resource.toString()
+            })
+        ), { placeholder: 'Select current working directory for new external terminal' });
+    }
+}

--- a/packages/terminal-external/src/electron-browser/terminal-external-frontend-module.ts
+++ b/packages/terminal-external/src/electron-browser/terminal-external-frontend-module.ts
@@ -1,0 +1,36 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { ContainerModule, interfaces } from 'inversify';
+import { CommandContribution } from '@theia/core/lib/common';
+import {
+    KeybindingContribution,
+    WebSocketConnectionProvider
+} from '@theia/core/lib/browser';
+import { bindTerminalExternalPreferences } from './terminal-external-preference';
+import { TerminalExternalFrontendContribution } from './terminal-external-contribution';
+import { TerminalExternalService, terminalExternalServicePath } from '../common/terminal-external';
+
+export default new ContainerModule((bind: interfaces.Bind) => {
+    bind(TerminalExternalFrontendContribution).toSelf().inSingletonScope();
+    bindTerminalExternalPreferences(bind);
+    [CommandContribution, KeybindingContribution].forEach(serviceIdentifier =>
+        bind(serviceIdentifier).toService(TerminalExternalFrontendContribution)
+    );
+    bind(TerminalExternalService).toDynamicValue(ctx =>
+        WebSocketConnectionProvider.createProxy<TerminalExternalService>(ctx.container, terminalExternalServicePath)
+    ).inSingletonScope();
+});

--- a/packages/terminal-external/src/electron-browser/terminal-external-preference.ts
+++ b/packages/terminal-external/src/electron-browser/terminal-external-preference.ts
@@ -1,0 +1,101 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { inject, injectable, interfaces, postConstruct } from 'inversify';
+import {
+    createPreferenceProxy,
+    PreferenceSchema,
+    PreferenceService,
+    PreferenceProxy
+} from '@theia/core/lib/browser';
+import { PreferenceSchemaProvider } from '@theia/core/lib/browser/preferences/preference-contribution';
+import { isWindows, isOSX } from '@theia/core/lib/common/os';
+import { TerminalExternalService, TerminalExternalConfiguration } from '../common/terminal-external';
+
+export const TerminalExternalPreferences = Symbol('TerminalExternalPreferences');
+export type TerminalExternalPreferences = PreferenceProxy<TerminalExternalConfiguration>;
+
+export const TerminalExternalSchemaPromise = Symbol('TerminalExternalSchemaPromise');
+export type TerminalExternalSchemaPromise = Promise<PreferenceSchema>;
+
+export function bindTerminalExternalPreferences(bind: interfaces.Bind): void {
+    bind(TerminalExternalSchemaPromise).toDynamicValue(
+        ctx => getTerminalExternalSchema(ctx.container.get(TerminalExternalService))
+    ).inSingletonScope();
+    bind(TerminalExternalPreferences).toDynamicValue(
+        ctx => createPreferenceProxy(
+            ctx.container.get(PreferenceService),
+            ctx.container.get(TerminalExternalSchemaPromise),
+        )
+    ).inSingletonScope();
+    bind(TerminalExternalPreferenceService).toSelf().inSingletonScope();
+}
+
+@injectable()
+export class TerminalExternalPreferenceService {
+
+    @inject(TerminalExternalPreferences)
+    private readonly preferences: TerminalExternalPreferences;
+
+    @inject(PreferenceSchemaProvider)
+    private readonly preferenceSchemaProvider: PreferenceSchemaProvider;
+
+    @inject(TerminalExternalSchemaPromise)
+    private readonly promisedSchema: TerminalExternalSchemaPromise;
+
+    @postConstruct()
+    protected setPreferenceSchema(): void {
+        this.promisedSchema.then(schema => this.preferenceSchemaProvider.setSchema(schema));
+    }
+
+    /**
+     * Get the external terminal configurations from preferences.
+     */
+    getTerminalExternalConfiguration(): TerminalExternalConfiguration {
+        return {
+            'terminal.external.linuxExec': this.preferences['terminal.external.linuxExec'],
+            'terminal.external.osxExec': this.preferences['terminal.external.osxExec'],
+            'terminal.external.windowsExec': this.preferences['terminal.external.windowsExec'],
+        };
+    }
+}
+
+/**
+ * Some of the schema's properties are fetched from the backend.
+ */
+export async function getTerminalExternalSchema(terminalExternalService: TerminalExternalService): Promise<PreferenceSchema> {
+    const hostExec = await terminalExternalService.getDefaultExec();
+    return {
+        type: 'object',
+        properties: {
+            'terminal.external.windowsExec': {
+                type: 'string',
+                description: 'Customizes which terminal to run on Windows.',
+                default: `${isWindows ? hostExec : 'C:\\WINDOWS\\System32\\cmd.exe'}`
+            },
+            'terminal.external.osxExec': {
+                type: 'string',
+                description: 'Customizes which terminal application to run on macOS.',
+                default: `${isOSX ? hostExec : 'Terminal.app'}`
+            },
+            'terminal.external.linuxExec': {
+                type: 'string',
+                description: 'Customizes which terminal to run on Linux.',
+                default: `${!(isWindows || isOSX) ? hostExec : 'xterm'}`
+            }
+        }
+    };
+}

--- a/packages/terminal-external/src/electron-node/terminal-external-backend-module.ts
+++ b/packages/terminal-external/src/electron-node/terminal-external-backend-module.ts
@@ -1,0 +1,48 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { ContainerModule, interfaces } from 'inversify';
+import { ConnectionHandler, JsonRpcConnectionHandler } from '@theia/core/lib/common';
+import { isWindows, isOSX } from '@theia/core/lib/common/os';
+import {
+    WindowsTerminalExternalService,
+    MacTerminalExternalService,
+    LinuxTerminalExternalService
+} from './terminal-external-service';
+import { TerminalExternalService, terminalExternalServicePath } from '../common/terminal-external';
+
+export function bindTerminalExternalService(bind: interfaces.Bind): void {
+    if (isWindows) {
+        bind(WindowsTerminalExternalService).toSelf().inSingletonScope();
+        bind(TerminalExternalService).toService(WindowsTerminalExternalService);
+    } else if (isOSX) {
+        bind(MacTerminalExternalService).toSelf().inSingletonScope();
+        bind(TerminalExternalService).toService(MacTerminalExternalService);
+    } else {
+        bind(LinuxTerminalExternalService).toSelf().inSingletonScope();
+        bind(TerminalExternalService).toService(LinuxTerminalExternalService);
+    }
+
+    bind(ConnectionHandler).toDynamicValue(ctx =>
+        new JsonRpcConnectionHandler(terminalExternalServicePath, () =>
+            ctx.container.get(TerminalExternalService)
+        )
+    ).inSingletonScope();
+}
+
+export default new ContainerModule(bind => {
+    bindTerminalExternalService(bind);
+});

--- a/packages/terminal-external/src/electron-node/terminal-external-service.ts
+++ b/packages/terminal-external/src/electron-node/terminal-external-service.ts
@@ -1,0 +1,195 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as cp from 'child_process';
+import * as path from 'path';
+import * as fs from 'fs-extra';
+import { injectable } from 'inversify';
+import { OS } from '@theia/core/lib/common/os';
+import { FileUri } from '@theia/core/lib/node/file-uri';
+import { TerminalExternalService, TerminalExternalConfiguration } from '../common/terminal-external';
+
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+// some code copied and modified from https://github.com/microsoft/vscode/blob/1.52.1/src/vs/workbench/contrib/externalTerminal/node/externalTerminalService.ts
+
+@injectable()
+export class WindowsTerminalExternalService implements TerminalExternalService {
+    private static readonly CMD = 'cmd.exe';
+
+    private static DEFAULT_TERMINAL_WINDOWS: string;
+
+    async openTerminal(configuration: TerminalExternalConfiguration, cwd: string): Promise<void> {
+        await this.spawnTerminal(configuration, FileUri.fsPath(cwd));
+    }
+
+    private async spawnTerminal(configuration: TerminalExternalConfiguration, cwd?: string): Promise<void> {
+        const terminalConfig = configuration['terminal.external.windowsExec'];
+        const exec = terminalConfig || WindowsTerminalExternalService.getDefaultTerminalWindows();
+
+        // Make the drive letter uppercase on Windows (https://github.com/microsoft/vscode/issues/9448).
+        if (cwd && cwd[1] === ':') {
+            cwd = cwd[0].toUpperCase() + cwd.substr(1);
+        }
+
+        // cmder ignores the environment cwd and instead opts to always open in %USERPROFILE%
+        // unless otherwise specified.
+        const basename = path.basename(exec).toLowerCase();
+        if (basename === 'cmder' || basename === 'cmder.exe') {
+            cp.spawn(exec, cwd ? [cwd] : undefined);
+            return;
+        }
+
+        const cmdArgs = ['/c', 'start', '/wait'];
+        // The "" argument is the window title. Without this, exec doesn't work when the path contains spaces.
+        if (exec.indexOf(' ') >= 0) {
+            cmdArgs.push('""');
+        }
+
+        cmdArgs.push(exec);
+
+        // Add starting directory parameter for Windows Terminal app.
+        if (basename === 'wt' || basename === 'wt.exe') {
+            cmdArgs.push('-d .');
+        }
+
+        return new Promise<void>(async (c, e) => {
+            const env = cwd ? { cwd } : undefined;
+            const command = this.getWindowsShell();
+            const child = cp.spawn(command, cmdArgs, env);
+            child.on('error', e);
+            child.on('exit', () => c());
+        });
+    }
+
+    async getDefaultExec(): Promise<string> {
+        return WindowsTerminalExternalService.getDefaultTerminalWindows();
+    }
+
+    /**
+     * Get the default terminal app on Windows.
+     * (determine and initialize the variable if not found).
+     */
+    public static getDefaultTerminalWindows(): string {
+        if (!WindowsTerminalExternalService.DEFAULT_TERMINAL_WINDOWS) {
+            const isWoW64 = !!process.env.hasOwnProperty('PROCESSOR_ARCHITEW6432');
+            WindowsTerminalExternalService.DEFAULT_TERMINAL_WINDOWS = `${process.env.windir ? process.env.windir : 'C:\\Windows'}\\${isWoW64 ? 'Sysnative' : 'System32'}\\cmd.exe`;
+        }
+        return WindowsTerminalExternalService.DEFAULT_TERMINAL_WINDOWS;
+    }
+
+    /**
+     * Find the Windows Shell process to start up (default to cmd.exe).
+     */
+    private getWindowsShell(): string {
+        // Find the path to cmd.exe if possible (%compsec% environment variable).
+        return process.env.compsec || WindowsTerminalExternalService.CMD;
+    }
+}
+
+@injectable()
+export class MacTerminalExternalService implements TerminalExternalService {
+    private static osxOpener = '/usr/bin/open';
+    private static defaultTerminalApp = 'Terminal.app';
+
+    async openTerminal(configuration: TerminalExternalConfiguration, cwd: string): Promise<void> {
+        await this.spawnTerminal(configuration, FileUri.fsPath(cwd));
+    }
+
+    private async spawnTerminal(configuration: TerminalExternalConfiguration, cwd?: string): Promise<void> {
+        const terminalConfig = configuration['terminal.external.osxExec'];
+        const terminalApp = terminalConfig || MacTerminalExternalService.getDefaultTerminalOSX();
+        return new Promise<void>((c, e) => {
+            const args = ['-a', terminalApp];
+            if (cwd) {
+                args.push(cwd);
+            }
+            const child = cp.spawn(MacTerminalExternalService.osxOpener, args);
+            child.on('error', e);
+            child.on('exit', () => c());
+        });
+    }
+
+    async getDefaultExec(): Promise<string> {
+        return MacTerminalExternalService.getDefaultTerminalOSX();
+    }
+
+    /**
+     * Get the default terminal app on OSX.
+     */
+    public static getDefaultTerminalOSX(): string {
+        return this.defaultTerminalApp;
+    }
+}
+
+@injectable()
+export class LinuxTerminalExternalService implements TerminalExternalService {
+    private static DEFAULT_TERMINAL_LINUX_READY: Promise<string>;
+
+    async openTerminal(configuration: TerminalExternalConfiguration, cwd: string): Promise<void> {
+        await this.spawnTerminal(configuration, FileUri.fsPath(cwd));
+    }
+
+    private async spawnTerminal(configuration: TerminalExternalConfiguration, cwd?: string): Promise<void> {
+        const terminalConfig = configuration['terminal.external.linuxExec'];
+        const execPromise = terminalConfig ? Promise.resolve(terminalConfig) : LinuxTerminalExternalService.getDefaultTerminalLinux();
+
+        return new Promise<void>((c, e) => {
+            execPromise.then(exec => {
+                const env = cwd ? { cwd } : undefined;
+                const child = cp.spawn(exec, [], env);
+                child.on('error', e);
+                child.on('exit', () => c());
+            });
+        });
+    }
+
+    async getDefaultExec(): Promise<string> {
+        return LinuxTerminalExternalService.getDefaultTerminalLinux();
+    }
+
+    /**
+     * Get the default terminal app on Linux.
+     * (determine and initialize the variable based on desktop environment if not found)
+     */
+    public static async getDefaultTerminalLinux(): Promise<string> {
+        if (!LinuxTerminalExternalService.DEFAULT_TERMINAL_LINUX_READY) {
+            LinuxTerminalExternalService.DEFAULT_TERMINAL_LINUX_READY = new Promise(async r => {
+                if (OS.type() === OS.Type.Linux) {
+                    const isDebian = await fs.pathExists('/etc/debian_version');
+                    if (isDebian) {
+                        r('x-terminal-emulator');
+                    } else if (process.env.DESKTOP_SESSION === 'gnome' || process.env.DESKTOP_SESSION === 'gnome-classic') {
+                        r('gnome-terminal');
+                    } else if (process.env.DESKTOP_SESSION === 'kde-plasma') {
+                        r('konsole');
+                    } else if (process.env.COLORTERM) {
+                        r(process.env.COLORTERM);
+                    } else if (process.env.TERM) {
+                        r(process.env.TERM);
+                    } else {
+                        r('xterm');
+                    }
+                } else {
+                    r('xterm');
+                }
+            });
+        }
+        return LinuxTerminalExternalService.DEFAULT_TERMINAL_LINUX_READY;
+    }
+}

--- a/packages/terminal-external/src/package.spec.ts
+++ b/packages/terminal-external/src/package.spec.ts
@@ -1,0 +1,29 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+/* note: this bogus test file is required so that
+  we are able to run mocha unit tests on this
+  package, without having any actual unit tests in it.
+  This way a coverage report will be generated,
+  showing 0% coverage, instead of no report.
+  This file can be removed once we have real unit
+  tests in place. */
+
+describe('terminal-external package', () => {
+
+    it('support code coverage statistics', () => true);
+
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -136,6 +136,9 @@
       "@theia/terminal/lib/*": [
         "packages/terminal/src/*"
       ],
+      "@theia/terminal-external/lib/*": [
+        "packages/terminal-external/src/*"
+      ],
       "@theia/typehierarchy/lib/*": [
         "packages/typehierarchy/src/*"
       ],


### PR DESCRIPTION
## What it does
<!-- Include relevant issues and describe how they are addressed. -->
+ Introduces a new extension: `@theia/terminal-external`. The extension adds support for spawning external terminals from Electron applications. In the future, the extension can be extended to support features such as spawning external terminals during debug sessions.

(**Browser applications should not pull this extension**).

#### Command:
+ Supports opening native terminals by calling `Open New External Terminal` from the command palette.

#### Preferences:
+ The PR contributes the following preferences:
	- `terminal.external.windowsExec`
	- `terminal.external.osxExec`
	- `terminal.external.linuxExec`
to allow users to customize the desired terminal application to run on their current platform. 
+ On startup, the backend determines the default terminal on the host machine, then sets the default field in the preference schema accordingly.
+ Changing the `Exec` preference of other OS than the current one won't have any effect. (i.e: Changing `osxExec` while running on Windows doesn't have any effect).

## How to test:
+ Verify the default `exec` of host OS is displaying the correct terminal.

Calling command `Open New External Terminal` has different behaviors, depending on the current workspace status:

#### No workspaces opened and no current active editor -> Spawn the terminal at the user home directory.

https://user-images.githubusercontent.com/43587865/110700880-76183780-81be-11eb-9a89-a85e73fe18e3.mp4


#### No workspaces opened but has an active editor -> Spawn the terminal at the parent folder of the active editor file.

https://user-images.githubusercontent.com/43587865/110700923-83352680-81be-11eb-9f74-2bedbf28c081.mp4


#### Only one workspace opened -> Spawn the terminal at the root of the current workspace.

https://user-images.githubusercontent.com/43587865/110700788-5bde5980-81be-11eb-99c8-2eacd73f0a72.mp4


#### Multi-root workspace opened -> Displays a quick pick to let users choose which workspace to spawn the terminal.

https://user-images.githubusercontent.com/43587865/110700703-40734e80-81be-11eb-8423-d6e72130b811.mp4


## Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

## Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Duc Nguyen <duc.a.nguyen@ericsson.com>
