### PR TITLE
monaco: Normalize hex color of different lengths

### DIFF
--- a/examples/api-tests/src/monaco-api.spec.js
+++ b/examples/api-tests/src/monaco-api.spec.js
@@ -198,7 +198,7 @@ describe.only('Monaco API', async function () {
 
             it('should normalize colors with different notations', () => {
                 assert.equal(themeRegistry['normalizeColor']('#FC0'), '#FFCC00');
-                assert.equal(themeRegistry['normalizeColor']('#FC0C'), '#FFCC00CC');
+                assert.equal(themeRegistry['normalizeColor']('#FC0C'), '#FFCC00');
                 assert.equal(themeRegistry['normalizeColor']('#FFCC00'), '#FFCC00');
             });
 

--- a/packages/monaco/src/browser/textmate/monaco-theme-registry.ts
+++ b/packages/monaco/src/browser/textmate/monaco-theme-registry.ts
@@ -139,13 +139,43 @@ export class MonacoThemeRegistry {
         if (!color) {
             return undefined;
         }
-        const normalized = String(color).replace(/^\#/, '').slice(0, 6);
-        if (normalized.length < 6 || !(normalized).match(/^[0-9A-Fa-f]{6}$/)) {
-            // ignoring not normalized colors to avoid breaking token color indexes between monaco and vscode-textmate
-            console.error(`Color '${normalized}' is NOT normalized, it must have 6 positions.`);
-            return undefined;
+
+        const hex = String(color).toUpperCase();
+        const length = hex.length;
+
+        // #RRGGBB notation.
+        if (length === 7 && hex.match(/#[A-Fa-f0-9]{6}/)) {
+            return hex;
         }
-        return '#' + normalized;
+
+        // #RRGGBBAA notation.
+        if (length === 9 && hex.match(/#[A-Fa-f0-9]{8}/)) {
+            const r = hex.charAt(1);
+            const g = hex.charAt(3);
+            const b = hex.charAt(5);
+            return '#' + r + r + g + g + b + b;
+        }
+
+        // #RGB notation.
+        if (length === 4 && hex.match(/#[A-Fa-f0-9]{3}/)) {
+            const r = hex.charAt(1);
+            const g = hex.charAt(2);
+            const b = hex.charAt(3);
+            return '#' + r + r + g + g + b + b;
+        }
+
+        // #RGBA notation.
+        if (length === 5 && hex.match(/#[A-Fa-f0-9]{4}/)) {
+            const r = hex.charAt(1);
+            const g = hex.charAt(2);
+            const b = hex.charAt(3);
+            const a = hex.charAt(4);
+            return '#' + r + r + g + g + b + b + a + a;
+        }
+
+        console.error(`Color '${hex}' cannot be normalized.`);
+        return undefined;
+
     }
 }
 

--- a/packages/monaco/src/browser/textmate/monaco-theme-registry.ts
+++ b/packages/monaco/src/browser/textmate/monaco-theme-registry.ts
@@ -144,12 +144,13 @@ export class MonacoThemeRegistry {
         const length = hex.length;
 
         // #RRGGBB notation.
-        if (length === 7 && hex.match(/#[A-Fa-f0-9]{6}/)) {
+        if (length === 7 && hex.match(/^#[A-Fa-f0-9]{6}$/)) {
             return hex;
         }
 
         // #RRGGBBAA notation.
-        if (length === 9 && hex.match(/#[A-Fa-f0-9]{8}/)) {
+        // Ignoring Alpha value to avoid breaking token color indexes between monaco and vscode-textmate.
+        if (length === 9 && hex.match(/^#[A-Fa-f0-9]{8}$/)) {
             const r = hex.charAt(1);
             const g = hex.charAt(3);
             const b = hex.charAt(5);
@@ -157,7 +158,7 @@ export class MonacoThemeRegistry {
         }
 
         // #RGB notation.
-        if (length === 4 && hex.match(/#[A-Fa-f0-9]{3}/)) {
+        if (length === 4 && hex.match(/^#[A-Fa-f0-9]{3}$/)) {
             const r = hex.charAt(1);
             const g = hex.charAt(2);
             const b = hex.charAt(3);
@@ -165,17 +166,16 @@ export class MonacoThemeRegistry {
         }
 
         // #RGBA notation.
-        if (length === 5 && hex.match(/#[A-Fa-f0-9]{4}/)) {
+        // Ignoring Alpha value to avoid breaking token color indexes between monaco and vscode-textmate.
+        if (length === 5 && hex.match(/^#[A-Fa-f0-9]{4}$/)) {
             const r = hex.charAt(1);
             const g = hex.charAt(2);
             const b = hex.charAt(3);
-            const a = hex.charAt(4);
-            return '#' + r + r + g + g + b + b + a + a;
+            return '#' + r + r + g + g + b + b;
         }
 
         console.error(`Color '${hex}' cannot be normalized.`);
         return undefined;
-
     }
 }
 


### PR DESCRIPTION

#### What it does
The commit adds handling for the following additional RGB formats:
  - #RRGGBBAA
  - #RGB
  - #RGBA

#### How to test
+ Download [Prism color theme](https://open-vsx.org/extension/usernamehw/prism) from open-vsx.
+ Set color theme to `Prism Light`.
+ Observe the theme is set correctly and no console errors (On master, there should be errors ouput since the plugin's author uses 3-value hex in the [code](https://github.com/usernamehw/vscode-theme-prism/blob/2a18e94efef3c6e6acc1ca62aa8f4bb15b787cb4/themes/Prism-color-theme.json#L42-L44))

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Duc Nguyen <duc.a.nguyen@ericsson.com>
