### PR TITLE
SIW: Support `search.smartCase`

### DIFF
--- a/packages/search-in-workspace/src/browser/search-in-workspace-preferences.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-preferences.ts
@@ -46,6 +46,11 @@ export const searchInWorkspacePreferencesSchema: PreferenceSchema = {
             description: 'Search the active editor when modified.',
             default: true,
             type: 'boolean',
+        },
+        'search.smartCase': {
+            description: 'Search case-insensitively if the pattern is all lowercase, otherwise, search case-sensitively.',
+            default: false,
+            type: 'boolean',
         }
     }
 };
@@ -56,6 +61,7 @@ export class SearchInWorkspaceConfiguration {
     'search.searchOnType': boolean;
     'search.searchOnTypeDebouncePeriod': number;
     'search.searchOnEditorModification': boolean;
+    'search.smartCase': boolean;
 }
 
 export const SearchInWorkspacePreferences = Symbol('SearchInWorkspacePreferences');


### PR DESCRIPTION
The following commit adds support for the preference 'search.smartCase'.
When the preference is true, search is case-insensitive if the pattern
is all lowercase, otherwise search is case-sensitive.

Signed-off-by: Duc Nguyen <duc.a.nguyen@ericsson.com>
